### PR TITLE
fix: search_trade_items silently dropped all stat filters

### DIFF
--- a/src/handlers/tradeHandlers.ts
+++ b/src/handlers/tradeHandlers.ts
@@ -27,6 +27,20 @@ function getTradeItemUrl(league: string, searchId: string, itemId: string): stri
   return `https://www.pathofexile.com/trade/search/${encodeURIComponent(league)}/${searchId}#${itemId}`;
 }
 
+// The MCP schema exposes `mods` with `stat_id` while the handler internally
+// uses `stats` with `id` (the PoE trade API shape). Accept both and normalize
+// so neither convention silently drops filters.
+export function toStatFilters(
+  stats?: Array<{ id: string; min?: number; max?: number }>,
+  mods?: Array<{ stat_id: string; min?: number; max?: number }>
+): Array<{ id: string; min?: number; max?: number }> {
+  if (stats && stats.length > 0) return stats;
+  if (mods && mods.length > 0) {
+    return mods.map((mod) => ({ id: mod.stat_id, min: mod.min, max: mod.max }));
+  }
+  return [];
+}
+
 /**
  * Search the Path of Exile trade site for items
  */
@@ -41,8 +55,10 @@ export async function handleSearchTradeItems(
     price_currency?: string;
     online_only?: boolean;
     rarity?: 'normal' | 'magic' | 'rare' | 'unique' | 'any';
+    item_rarity?: 'normal' | 'magic' | 'rare' | 'unique' | 'any';
     min_links?: number;
     stats?: Array<{ id: string; min?: number; max?: number }>;
+    mods?: Array<{ stat_id: string; min?: number; max?: number }>;
     sort?: 'price_asc' | 'price_desc';
     limit?: number;
   }
@@ -62,8 +78,10 @@ export async function handleSearchTradeItems(
       price_currency = 'chaos',
       online_only = true,
       rarity,
+      item_rarity,
       min_links,
       stats,
+      mods,
       sort = 'price_asc',
       limit = 5,
     } = args;
@@ -79,16 +97,18 @@ export async function handleSearchTradeItems(
       builder.withType(item_type);
     }
 
-    if (rarity) {
-      builder.withRarity(rarity);
+    const effectiveRarity = rarity ?? item_rarity;
+    if (effectiveRarity) {
+      builder.withRarity(effectiveRarity);
     }
 
     if (min_links) {
       builder.withLinks(min_links);
     }
 
-    if (stats && stats.length > 0) {
-      builder.withStats(stats);
+    const statFilters = toStatFilters(stats, mods);
+    if (statFilters.length > 0) {
+      builder.withStats(statFilters);
     }
 
     builder.applyOptions({

--- a/tests/unit/tradeHandlers.test.ts
+++ b/tests/unit/tradeHandlers.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from '@jest/globals';
+import { toStatFilters } from '../../src/handlers/tradeHandlers.js';
+
+describe('toStatFilters', () => {
+  it('returns an empty array when neither stats nor mods are provided', () => {
+    expect(toStatFilters(undefined, undefined)).toEqual([]);
+    expect(toStatFilters([], [])).toEqual([]);
+  });
+
+  it('returns stats[] as-is when only stats are provided (handler-native shape)', () => {
+    const stats = [
+      { id: 'explicit.stat_3372524247', min: 35 },
+      { id: 'explicit.stat_3299347043', min: 90, max: 200 },
+    ];
+    expect(toStatFilters(stats, undefined)).toEqual(stats);
+  });
+
+  it('maps mods[].stat_id to stats[].id when only mods are provided (MCP-schema shape)', () => {
+    const mods = [
+      { stat_id: 'explicit.stat_3372524247', min: 35 },
+      { stat_id: 'explicit.stat_3299347043', min: 90, max: 200 },
+    ];
+    expect(toStatFilters(undefined, mods)).toEqual([
+      { id: 'explicit.stat_3372524247', min: 35 },
+      { id: 'explicit.stat_3299347043', min: 90, max: 200 },
+    ]);
+  });
+
+  it('prefers stats over mods when both are provided', () => {
+    const stats = [{ id: 'explicit.stat_A', min: 1 }];
+    const mods = [{ stat_id: 'explicit.stat_B', min: 2 }];
+    expect(toStatFilters(stats, mods)).toEqual(stats);
+  });
+
+  it('preserves missing min/max when mapping mods to stats', () => {
+    const mods = [{ stat_id: 'explicit.stat_X' }];
+    expect(toStatFilters(undefined, mods)).toEqual([
+      { id: 'explicit.stat_X', min: undefined, max: undefined },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

`search_trade_items` was silently ignoring every `mods`/`item_rarity` filter
passed from MCP clients. The MCP schema exposes:

- `mods: [{ stat_id, min, max }]`
- `item_rarity: 'rare' | ...`

…but [`handleSearchTradeItems`](https://github.com/ianderse/pob-mcp/blob/main/src/handlers/tradeHandlers.ts#L33) destructures `stats` and `rarity` —
the internal PoE trade API shape. The router passes `args` straight through
without transformation, so the destructured values were always `undefined`
and the filters got dropped on the floor.

**Symptom:** any MCP `search_trade_items` call returns the unfiltered
"all items in league" set (capped at 10 000), regardless of what the
caller asked for.

## Fix

Accept both naming conventions in the handler and normalize to the
internal shape via a small `toStatFilters` helper. Backward compatible —
existing callers using `stats`/`rarity` continue to work, and MCP clients
using the schema-correct `mods`/`item_rarity` now actually filter.

## Credit

Original spot and patch by @Joeyvan69 in [Joeyvan69/pob-mcp](https://github.com/Joeyvan69/pob-mcp/blob/main/src/handlers/tradeHandlers.ts);
upstreaming with credit. Their fork-only patch never made it back here, so
the bug has been live on `main` for a while.

## Test plan

- [x] Added `tests/unit/tradeHandlers.test.ts` covering the helper:
  empty input, stats-only, mods-only, both (stats wins), missing min/max
- [x] `npm run build` — clean
- [x] `npm test -- --testPathPattern=tradeHandlers` — 5/5 pass
- [ ] Manual sanity check on a live trade search after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)