### PR TITLE
feat(anoint): add find_best_anointment MCP tool

### DIFF
--- a/src/handlers/anointHandlers.ts
+++ b/src/handlers/anointHandlers.ts
@@ -1,0 +1,73 @@
+import { wrapHandler } from '../utils/errorHandling.js';
+import type { PoBLuaApiClient } from '../pobLuaBridge.js';
+
+interface AnointHandlerContext {
+  getLuaClient: () => PoBLuaApiClient | null;
+  ensureLuaClient: () => Promise<void>;
+}
+
+/**
+ * Find the best anointable notable for the loaded build by simulating the
+ * impact of each anoint candidate via PoB's MiscCalculator (non-destructive,
+ * same mechanism the GUI uses to sort anoints in the item picker).
+ *
+ * Requires an anointable item equipped in the target slot:
+ * - Amulet (any base)
+ * - Belt: Cord Belt only
+ */
+export async function handleFindBestAnointment(
+  context: AnointHandlerContext,
+  args: { slot: string; focus?: 'dps' | 'defence' | 'both'; max_results?: number },
+) {
+  return wrapHandler('find best anointment', async () => {
+    await context.ensureLuaClient();
+    const client = context.getLuaClient();
+    if (!client) {
+      throw new Error('Lua bridge not active. Use lua_start and lua_load_build first.');
+    }
+
+    if (!args || typeof args.slot !== 'string' || args.slot.trim() === '') {
+      throw new Error('slot is required (e.g. "Amulet" or "Belt")');
+    }
+    const focus = args.focus ?? 'both';
+    const maxResults = args.max_results ?? 10;
+
+    const result = await client.evaluateAnointCandidates({
+      slot: args.slot,
+      focus,
+      // Pull a generous candidate set; we display max_results.
+      limit: Math.max(maxResults, 50),
+    });
+
+    const lines: string[] = [
+      `=== Best Anointment (slot: ${result.slot} / ${result.baseType}, focus: ${result.focus}) ===`,
+      '',
+      `Base CombinedDPS: ${Math.round(result.base.CombinedDPS).toLocaleString()}  |  Base TotalEHP: ${Math.round(result.base.TotalEHP).toLocaleString()}`,
+      `Evaluated ${result.evaluated} anointable notables (${result.skipped} skipped), showing top ${Math.min(maxResults, result.candidates.length)}:`,
+      '',
+    ];
+
+    const top = result.candidates.slice(0, maxResults);
+    for (let i = 0; i < top.length; i++) {
+      const c = top[i];
+      const dpsPct = result.base.CombinedDPS > 0 ? (c.dpsDelta / result.base.CombinedDPS) * 100 : 0;
+      const ehpPct = result.base.TotalEHP > 0 ? (c.ehpDelta / result.base.TotalEHP) * 100 : 0;
+      lines.push(
+        `${i + 1}. **${c.name}** [${c.nodeId}]`,
+        `   Score: ${c.score.toFixed(4)}  |  DPS Δ: ${c.dpsDelta >= 0 ? '+' : ''}${Math.round(c.dpsDelta).toLocaleString()} (${dpsPct >= 0 ? '+' : ''}${dpsPct.toFixed(2)}%)  |  EHP Δ: ${c.ehpDelta >= 0 ? '+' : ''}${Math.round(c.ehpDelta).toLocaleString()} (${ehpPct >= 0 ? '+' : ''}${ehpPct.toFixed(2)}%)`,
+      );
+      if (c.recipe && c.recipe.length > 0) {
+        lines.push(`   Oils: ${c.recipe.join(' + ')}`);
+      }
+      lines.push('');
+    }
+
+    if (top.length === 0) {
+      lines.push('No anointable candidates evaluated. Verify a build is loaded and the target slot has an anointable item.');
+    }
+
+    return {
+      content: [{ type: 'text' as const, text: lines.join('\n') }],
+    };
+  });
+}

--- a/src/pobLuaBridge.ts
+++ b/src/pobLuaBridge.ts
@@ -429,6 +429,28 @@ async setTree(params: {
     return res.output;
   }
 
+  async evaluateAnointCandidates(params: { slot: string; focus?: 'dps' | 'defence' | 'both'; limit?: number }): Promise<{
+    candidates: Array<{ nodeId: number; name: string; dpsDelta: number; ehpDelta: number; score: number; recipe?: string[] }>;
+    base: { CombinedDPS: number; TotalEHP: number };
+    evaluated: number;
+    skipped: number;
+    slot: string;
+    baseType: string;
+    focus: string;
+  }> {
+    const res = await this.send({ action: "evaluate_anoint_candidates", params });
+    if (!res.ok) throw new Error(res.error || "evaluate_anoint_candidates failed");
+    return {
+      candidates: (res.candidates as Array<{ nodeId: number; name: string; dpsDelta: number; ehpDelta: number; score: number; recipe?: string[] }>) || [],
+      base: (res.base as { CombinedDPS: number; TotalEHP: number }) || { CombinedDPS: 0, TotalEHP: 0 },
+      evaluated: Number(res.evaluated) || 0,
+      skipped: Number(res.skipped) || 0,
+      slot: String(res.slot ?? ''),
+      baseType: String(res.baseType ?? ''),
+      focus: String(res.focus ?? 'both'),
+    };
+  }
+
   async getMasteryOptions(): Promise<any> {
     const res = await this.send({ action: "get_mastery_options" });
     if (!res.ok) throw new Error(res.error || "get_mastery_options failed");

--- a/src/server/toolRouter.ts
+++ b/src/server/toolRouter.ts
@@ -16,6 +16,7 @@ import type { PoeNinjaClient } from "../services/poeNinjaClient.js";
 import { handleListBuilds, handleAnalyzeBuild, handleCompareBuilds, handleGetBuildStats, handleGetBuildNotes, handleSetBuildNotes } from "../handlers/buildHandlers.js";
 import { handleStartWatching, handleStopWatching, handleGetRecentChanges, handleWatchStatus, handleRefreshTreeData } from "../handlers/watchHandlers.js";
 import { handleCompareTrees, handleGetNearbyNodes, handleFindPath, handleGetPassiveUpgrades, handleSuggestMasteries } from "../handlers/treeHandlers.js";
+import { handleFindBestAnointment } from "../handlers/anointHandlers.js";
 import { handleGetBuildIssues, formatIssuesResponse } from "../handlers/buildGoalsHandlers.js";
 import { handleLuaStart, handleLuaStop, handleLuaNewBuild, handleLuaSaveBuild, handleLuaLoadBuild, handleLuaGetStats, handleLuaGetTree, handleLuaSetTree, handleSearchTreeNodes, handleLuaGetBuildInfo, handleLuaReloadBuild, handleUpdateTreeDelta, handleCreateSpec, handleListSpecs, handleSelectSpec, handleDeleteSpec, handleRenameSpec, handleListItemSets, handleSelectItemSet } from "../handlers/luaHandlers.js";
 import { handleAddItem, handleGetEquippedItems, handleToggleFlask, handleGetSkillSetup, handleSetMainSkill, handleCreateSocketGroup, handleAddGem, handleSetGemLevel, handleSetGemQuality, handleRemoveSkill, handleRemoveGem, handleSetupSkillWithGems, handleAddMultipleItems, handleSetSocketGroupEnabled, handleSetGemEnabled } from "../handlers/itemSkillHandlers.js";
@@ -682,6 +683,21 @@ export async function routeToolCall(
       const focus = (args?.focus as 'dps' | 'defence' | 'both') || 'both';
       const maxResults = (args?.max_results as number) || 10;
       return await handleGetPassiveUpgrades(upgradesContext, focus, maxResults);
+    }
+
+    case "find_best_anointment": {
+      if (!args || typeof args.slot !== 'string') {
+        throw new Error('find_best_anointment requires a "slot" argument');
+      }
+      const anointContext = {
+        getLuaClient: deps.getLuaClient,
+        ensureLuaClient: deps.ensureLuaClient,
+      };
+      return await handleFindBestAnointment(anointContext, {
+        slot: args.slot as string,
+        focus: args.focus as 'dps' | 'defence' | 'both' | undefined,
+        max_results: args.max_results as number | undefined,
+      });
     }
 
     case "analyze_build_cluster_jewels":

--- a/src/server/toolSchemas.ts
+++ b/src/server/toolSchemas.ts
@@ -1595,6 +1595,29 @@ export function getBuildGoalsToolSchemas(): any[] {
       },
     },
     {
+      name: "find_best_anointment",
+      description: "Rank the best anointable notables for the loaded build by simulating the impact of each anoint via PoB's MiscCalculator (non-destructive, same engine the GUI uses to sort anoints in the item picker). Iterates ALL anointable notables across the tree (~400) — not a keyword-filtered subset. Requires an anointable item equipped in the target slot: any Amulet, or a Cord Belt for the Belt slot.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          slot: {
+            type: "string",
+            description: "Slot of the anointable item: 'Amulet' or 'Belt' (Belt only works if a Cord Belt is equipped).",
+          },
+          focus: {
+            type: "string",
+            description: "What to optimize for (default: 'both'). 'dps' = pure DPS impact, 'defence' = pure EHP impact, 'both' = combined (DPS weight 1.0, EHP weight 0.5 — matches PoB's TradeQueryGenerator defaults).",
+            enum: ["dps", "defence", "both"],
+          },
+          max_results: {
+            type: "number",
+            description: "Maximum number of anoint candidates to return (default: 10).",
+          },
+        },
+        required: ["slot"],
+      },
+    },
+    {
       name: "analyze_build_cluster_jewels",
       description: "Analyze the cluster jewels currently equipped in the build, evaluate which notables synergize with the build archetype, and flag wasted notables",
       inputSchema: {


### PR DESCRIPTION
## Summary

New `find_best_anointment` MCP tool that ranks anointable notables by their
real DPS/EHP impact on the loaded build, using PoB's `MiscCalculator`
(non-destructive) — same engine the GUI uses to sort anoints in the item
picker.

## Why this exists

The existing `get_passive_upgrades` tool is broken for anoint searches in two ways:

1. **State pollution** — `calcWith` mutates build state across iterations.
   On a build with ~30+ candidates, `CombinedDPS` collapses to ~0 and all
   subsequent baseline calcs return broken values (verified live: after one
   `get_passive_upgrades` call, `lua_get_stats` shows `CombinedDPS: 0.06`
   on a build that started at 1 031 293).
2. **Scope too narrow** — candidates are filtered via 4 keyword searches ×
   15 nodes each, yielding ~60 max. For an anoint, the right scope is **all
   ~400 anointable notables across the entire tree**, not just keyword-matched
   ones reachable from the current allocation.

`get_passive_upgrades` is fine for "what notable should I allocate next from
my current tree position" (its actual use case). It is **not** the right tool
for anointment selection.

## How

Pairs with [PathOfBuilding feat/best-anointment-handler](https://github.com/mcagnion/PathOfBuilding/tree/feat/best-anointment-handler)
which adds the `evaluate_anoint_candidates` JSON-RPC action on the Lua side.

The Lua handler:
- Iterates `build.spec.tree.nodes`, keeping only anointable notables (those
  with a `recipe` and not currently allocated)
- Uses `build.calcsTab:GetMiscCalculator()` + `itemsTab:anointItem(node)` for
  each candidate — exactly the same pattern as
  [`NotableDBControl:ListBuilder()`](https://github.com/PathOfBuildingCommunity/PathOfBuilding/blob/dev/src/Classes/NotableDBControl.lua#L127-L160)
  uses to power the GUI's anoint sort
- Saves and restores `displayItem` / `anointEnchantSlot` so repeated calls
  don't pollute build state

The MCP tool surfaces this as `find_best_anointment(slot, focus, max_results)`
and formats the top N with DPS Δ / EHP Δ in absolute and percent terms, plus
the oil combination required for each anoint.

## Live verification

Tested on a level 84 Saboteur build (Mirage league, 1 031 293 CombinedDPS,
10 646 EHP):

```
=== Best Anointment (slot: Amulet / Amulet, focus: both) ===
Base CombinedDPS: 1 031 293  |  Base TotalEHP: 10 646
Evaluated 449 anointable notables (0 skipped), showing top 10:

1. Lava Lash         Score: 0.1675  DPS Δ: +172 736 (+16.75%)  EHP Δ: 0
2. Forces of Nature  Score: 0.1515  DPS Δ: +156 282 (+15.15%)  EHP Δ: 0
3. Prism Weave       Score: 0.1452  DPS Δ: +149 709 (+14.52%)  EHP Δ: 0
4. Light of Divinity Score: 0.1423  DPS Δ: +145 047 (+14.06%)  EHP Δ: +34
...
```

449 candidates evaluated, 0 skipped — full tree coverage with no state
pollution. `lua_get_stats` after the call confirms baseline values are
unchanged (vs `get_passive_upgrades` which collapses them to ~0).

## Test plan

- [x] `npm run build` clean
- [x] Live e2e on real build, returns plausible rankings with Δ values
- [x] State preserved across calls (verified via `lua_get_stats` after)
- [ ] Cord Belt path: works the same way once a Cord Belt is equipped
  (verifiable but requires the user to swap belts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)