### PR TITLE
fix: make compare_builds usable on a fresh Lua bridge

### DIFF
--- a/src/handlers/buildHandlers.ts
+++ b/src/handlers/buildHandlers.ts
@@ -6,6 +6,7 @@ import type { HandlerContext } from "../utils/contextBuilder.js";
 import fs from "fs/promises";
 import { wrapHandler } from "../utils/errorHandling.js";
 import { sanitizeBuildName } from "../utils/pathSanitizer.js";
+import { BOOTSTRAP_BUILD_NAME } from "../server/bootstrapBuild.js";
 export type { HandlerContext } from "../utils/contextBuilder.js";
 
 export async function handleListBuilds(context: HandlerContext) {
@@ -259,7 +260,13 @@ export async function handleCompareBuilds(context: HandlerContext, build1Name: s
       }
     } catch { /* ignore */ }
 
-    const stats = await luaClient.getStats();
+    // get_stats defaults to defence-only fields, so the offensive rows below have
+    // to be requested by name — otherwise DPS and crit always render as "N/A".
+    const stats = await luaClient.getStats([
+      'Life', 'EnergyShield', 'TotalEHP', 'Mana',
+      'TotalDPS', 'CombinedDPS', 'MinionTotalDPS', 'CritChance', 'CritMultiplier',
+      'FireResist', 'ColdResist', 'LightningResist', 'ChaosResist',
+    ]);
     return { stats, selectedSpec, selectedItemSet, displayName };
   };
 
@@ -282,7 +289,9 @@ export async function handleCompareBuilds(context: HandlerContext, build1Name: s
       const info = await luaClient.getBuildInfo();
       loadedName = info?.name ?? '';
     } catch { /* no build loaded yet — safe to load */ }
-    if (loadedName) {
+    // The bootstrap build is not user work — a freshly started bridge always holds
+    // it, so treating it as unsaved changes would block compare_builds outright.
+    if (loadedName && loadedName !== BOOTSTRAP_BUILD_NAME) {
       const loaded = basename(loadedName);
       if (loaded !== basename(build1Name) && loaded !== basename(build2Name)) {
         throw new Error(

--- a/src/server/bootstrapBuild.ts
+++ b/src/server/bootstrapBuild.ts
@@ -1,0 +1,9 @@
+/**
+ * Name of the throwaway build the Lua bridge loads to prove HeadlessWrapper came
+ * up. It is not user work, so guards that protect unsaved builds must not mistake
+ * it for one.
+ *
+ * Kept in its own module so guards can import it without pulling in the bridge
+ * lifecycle (which uses `import.meta` and cannot load under the CommonJS tests).
+ */
+export const BOOTSTRAP_BUILD_NAME = 'Init Test';

--- a/src/server/luaClientManager.ts
+++ b/src/server/luaClientManager.ts
@@ -5,6 +5,7 @@
  */
 
 import { PoBLuaApiClient } from '../pobLuaBridge.js';
+import { BOOTSTRAP_BUILD_NAME } from './bootstrapBuild.js';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -92,7 +93,7 @@ export class LuaClientManager {
 
       while (attempts < maxAttempts) {
         try {
-          await stdioClient.loadBuildXml(testXml, 'Init Test');
+          await stdioClient.loadBuildXml(testXml, BOOTSTRAP_BUILD_NAME);
           console.error('[Lua Bridge] HeadlessWrapper fully initialized');
           break;
         } catch (loadError) {

--- a/tests/unit/buildHandlers.test.ts
+++ b/tests/unit/buildHandlers.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
+
+// loadEndgame reads the build file off disk before handing it to the bridge.
+jest.mock('fs/promises', () => ({
+  __esModule: true,
+  default: { readFile: jest.fn(async () => '<?xml version="1.0"?><PathOfBuilding/>') },
+}));
+
 import {
   handleListBuilds,
   handleAnalyzeBuild,
@@ -6,6 +13,7 @@ import {
   handleGetBuildStats,
   type HandlerContext,
 } from '../../src/handlers/buildHandlers.js';
+import { BOOTSTRAP_BUILD_NAME } from '../../src/server/bootstrapBuild.js';
 import { BuildService } from '../../src/services/buildService.js';
 import { TreeService } from '../../src/services/treeService.js';
 import type { PoBBuild } from '../../src/types.js';
@@ -262,6 +270,54 @@ describe('BuildHandlers', () => {
 
       expect(result.content[0].text).toContain('Life: 4500 vs 5000');
       expect(result.content[0].text).toContain('TotalDPS: 1000000 vs 800000');
+    });
+
+    it('should compare when the bridge only holds the bootstrap build', async () => {
+      // A freshly started bridge always holds the bootstrap build. Treating it as
+      // unsaved user work made compare_builds fail until a build was loaded first.
+      mockBuildService.readBuild.mockResolvedValueOnce(build1).mockResolvedValueOnce(build2);
+      context.getLuaClient = () => ({
+        getBuildInfo: async () => ({ name: BOOTSTRAP_BUILD_NAME }),
+        loadBuild: async () => { throw new Error('lua unavailable in test'); },
+      }) as any;
+
+      const result = await handleCompareBuilds(context, 'build1.xml', 'build2.xml');
+
+      expect(result.content[0].text).toContain('Build Comparison');
+    });
+
+    it('should still refuse to clobber a different loaded build', async () => {
+      mockBuildService.readBuild.mockResolvedValueOnce(build1).mockResolvedValueOnce(build2);
+      context.getLuaClient = () => ({
+        getBuildInfo: async () => ({ name: 'My Unsaved League Starter' }),
+        loadBuild: async () => { throw new Error('should never be reached'); },
+      }) as any;
+
+      await expect(handleCompareBuilds(context, 'build1.xml', 'build2.xml'))
+        .rejects.toThrow('My Unsaved League Starter');
+    });
+
+    it('should report live DPS instead of N/A', async () => {
+      // get_stats returns defence-only fields unless offensive ones are named,
+      // which left the most important row of the comparison permanently blank.
+      let requestedFields: string[] | undefined;
+      const statsFor = (dps: number) => ({ Life: 4000, CombinedDPS: dps, CritChance: 50 });
+      let call = 0;
+      context.getLuaClient = () => ({
+        loadBuildXml: async () => ({ ok: true }),
+        listSpecs: async () => ({ specs: [] }),
+        listItemSets: async () => ({ itemSets: [] }),
+        getStats: async (fields?: string[]) => {
+          requestedFields = fields;
+          return statsFor(call++ === 0 ? 1_500_000 : 900_000);
+        },
+      }) as any;
+
+      const result = await handleCompareBuilds(context, 'build1.xml', 'build2.xml');
+
+      expect(requestedFields).toContain('CombinedDPS');
+      expect(result.content[0].text).toContain('1.500.000');
+      expect(result.content[0].text).not.toMatch(/DPS \(combined\).*N\/A/);
     });
 
     it('should handle builds with single PlayerStat object', async () => {


### PR DESCRIPTION
`compare_builds` was unusable in two independent ways. I hit both while setting the server up against a stock `PathOfBuildingCommunity` checkout for 3.29 league start.

## 1. It refused to run at all

The bridge loads a throwaway build named `Init Test` during startup to prove `HeadlessWrapper` came up (`luaClientManager.ts`). The guard in `handleCompareBuilds` that protects unsaved user work compares the loaded build's name against the two requested builds, doesn't match, and throws:

```
A different build ("Init Test") is currently loaded in the Lua bridge and may
have unsaved changes. compare_builds would replace it. Save it first with
lua_save_build, then re-run compare_builds.
```

Because a freshly started bridge *always* holds the bootstrap build, the first `compare_builds` call of every session failed. The suggested remedy makes it worse — `lua_save_build` would have written the throwaway level-1 Witch over something.

The bootstrap name now lives in `src/server/bootstrapBuild.ts` so the guard can recognise and skip it. It's a separate module rather than an export from `luaClientManager` because that module uses `import.meta`, which can't be loaded from the CommonJS test environment (`TS1343`).

The guard still fires for real builds — covered by a test.

## 2. Once it ran, DPS was always `N/A`

```
  DPS (combined)                 N/A  vs           N/A  =
  Crit Chance %                  N/A  vs           N/A  =
  Crit Multi %                   N/A  vs           N/A  =
```

`loadEndgame` called `luaClient.getStats()` with no field list. `export_stats` in `lua/pob_ops.lua` defaults to a defence-only field list — no `TotalDPS`, no `CombinedDPS`, no `CritChance` — so the offensive rows could never be populated. Every other caller in the codebase (`luaHandlers.ts`) passes an explicit list; this one now does too.

## Verification

Full suite passes (258 tests, 17 suites) and `tsc` is clean. Three new tests cover the bootstrap case, the still-guarded case, and the DPS regression.

End-to-end against a real PoB checkout — fresh bridge, `lua_start`, then `compare_builds` as the very next call:

```
Stat                         Build 1            Build 2
------------------------------------------------------------
  Life                         3.375  vs         3.375  =
  Total EHP                  281.933  vs       281.933  =

  DPS (combined)           3.519.872  vs     2.360.313  ▲1
  Crit Chance %                   23  vs            23  =
```
