### PR TITLE
fix: honour build_name in plan_leveling, and read the active skill set

### DIFF
--- a/src/handlers/advancedOptimizationHandlers.ts
+++ b/src/handlers/advancedOptimizationHandlers.ts
@@ -12,6 +12,7 @@ import {
   type SkillGroup,
 } from "../skillLinkOptimizer.js";
 import { sanitizeBuildName } from "../utils/pathSanitizer.js";
+import { activeSkillSet, asArray } from "../utils/xmlCollections.js";
 
 export interface AdvancedOptimizationContext {
   buildService: BuildService;
@@ -235,12 +236,9 @@ export async function handleOptimizeSkillLinks(
       );
 
       // Extract skills from XML
-      if (build.Skills?.SkillSet?.Skill) {
-        const skills = Array.isArray(build.Skills.SkillSet.Skill)
-          ? build.Skills.SkillSet.Skill
-          : [build.Skills.SkillSet.Skill];
-
-        skillGroups = skills.map((skill: any, idx) => {
+      const skills = asArray(activeSkillSet(build)?.Skill);
+      if (skills.length > 0) {
+        skillGroups = skills.map((skill: any, idx: number) => {
           const gems = Array.isArray(skill.Gem) ? skill.Gem : skill.Gem ? [skill.Gem] : [];
 
           return {
@@ -316,10 +314,8 @@ export async function handleCreateBudgetBuild(
 
     // Get main skill from first skill group
     let main_skill = 'your main skill';
-    if (build.Skills?.SkillSet?.Skill) {
-      const skills = Array.isArray(build.Skills.SkillSet.Skill)
-        ? build.Skills.SkillSet.Skill
-        : [build.Skills.SkillSet.Skill];
+    {
+      const skills = asArray(activeSkillSet(build)?.Skill);
       const firstSkill = skills[0];
       if (firstSkill?.Gem) {
         const gems = Array.isArray(firstSkill.Gem) ? firstSkill.Gem : [firstSkill.Gem];

--- a/src/handlers/levelingHandlers.ts
+++ b/src/handlers/levelingHandlers.ts
@@ -7,11 +7,40 @@
  */
 
 import type { PoBLuaApiClient } from "../pobLuaBridge.js";
+import type { PoBBuild, PoBGem, PoBSkill } from "../types.js";
 import { wrapHandler } from "../utils/errorHandling.js";
+import { activeSkillSet, asArray } from "../utils/xmlCollections.js";
 
 export interface LevelingContext {
   getLuaClient: () => PoBLuaApiClient | null;
   ensureLuaClient: () => Promise<void>;
+  // Supplied so build_name can be honoured; absent contexts fall back to the bridge.
+  readBuild?: (buildName: string) => Promise<PoBBuild>;
+}
+
+/** Reads class, ascendancy and main skill straight out of a saved build file. */
+function describeBuild(build: PoBBuild): {
+  className?: string;
+  ascendancy?: string;
+  mainSkill?: string;
+} {
+  const className = build.Build?.className;
+  const ascendancy = build.Build?.ascendClassName;
+
+  const groups = asArray<PoBSkill>(activeSkillSet(build)?.Skill);
+
+  // mainSocketGroup is 1-based and indexes the socket groups of the active set.
+  const groupIndex = Number(build.Build?.mainSocketGroup ?? 1) - 1;
+  const group = groups[groupIndex] ?? groups[0];
+
+  // Supports share the <Gem> element with actives, so pick the actives out first.
+  const actives = asArray<PoBGem>(group?.Gem).filter(
+    g => !(g.gemId ?? '').includes('SupportGem') && !(g.skillId ?? '').startsWith('Support')
+  );
+  const activeIndex = Number(group?.mainActiveSkill ?? 1) - 1;
+  const mainSkill = (actives[activeIndex] ?? actives[0])?.nameSpec;
+
+  return { className, ascendancy, mainSkill };
 }
 
 // Act-by-act milestone levels (PoE 1 campaign)
@@ -54,9 +83,23 @@ export async function handlePlanLeveling(
   let mainSkill = args.main_skill;
   let ascendancy = args.ascendancy;
 
+  // A named build is the most specific source, and the caller clearly meant that
+  // one — read it before falling back to whatever the bridge happens to hold.
+  if (args.build_name) {
+    if (!context.readBuild) {
+      throw new Error('build_name is not supported in this context — pass class_name and main_skill instead.');
+    }
+    // Guessing a class for a build the user named by hand would produce a
+    // confidently wrong guide, so let the read error surface instead.
+    const described = describeBuild(await context.readBuild(args.build_name));
+    className = className || described.className;
+    ascendancy = ascendancy || described.ascendancy;
+    mainSkill = mainSkill || described.mainSkill;
+  }
+
   // Try to read info from the currently loaded Lua build
   const luaClient = context.getLuaClient();
-  if (luaClient) {
+  if (luaClient && !(className && ascendancy && mainSkill)) {
     try {
       const info = await luaClient.getBuildInfo();
       className = className || info.className;
@@ -80,6 +123,7 @@ export async function handlePlanLeveling(
   }
 
   // Defaults when neither Lua nor args provide a value
+  const classResolved = Boolean(className);
   className = className || 'Witch';
   mainSkill = mainSkill || 'your main skill';
   ascendancy = ascendancy || 'Unknown';
@@ -88,6 +132,11 @@ export async function handlePlanLeveling(
 
   let output = `# Leveling Guide: ${className} (${ascendancy})\n`;
   output += `**Main Skill:** ${mainSkill}\n\n`;
+  if (!classResolved) {
+    // Without this the placeholder class reads like a recommendation.
+    output += `> No build was resolved, so this is the generic ${className} outline. ` +
+      `Pass \`build_name\`, or \`class_name\` and \`main_skill\`, for a guide that matches your build.\n\n`;
+  }
 
   output += `## Before Your Main Skill is Available\n`;
   output += `Use: **${starter.early}**\n`;

--- a/src/server/toolRouter.ts
+++ b/src/server/toolRouter.ts
@@ -723,7 +723,12 @@ export async function routeToolCall(
 
     case "plan_leveling":
       return await handlePlanLeveling(
-        { getLuaClient: deps.getLuaClient, ensureLuaClient: deps.ensureLuaClient },
+        {
+          getLuaClient: deps.getLuaClient,
+          ensureLuaClient: deps.ensureLuaClient,
+          readBuild: (name: string) =>
+            deps.contextBuilder.buildHandlerContext().buildService.readBuild(name),
+        },
         args || {}
       );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,29 @@ export interface TreeDataCache {
   timestamp: number;
 }
 
+export interface PoBGem {
+  nameSpec?: string;
+  name?: string;
+  level?: string;
+  quality?: string;
+  skillId?: string;
+  // "Metadata/Items/Gems/SupportGem..." for supports, "...SkillGem..." for actives
+  gemId?: string;
+}
+
+export interface PoBSkillSet {
+  id?: string;
+  Skill?: PoBSkill | PoBSkill[];
+}
+
+export interface PoBSkill {
+  enabled?: string;
+  slot?: string;
+  // 1-based index of the active skill used for DPS within this socket group
+  mainActiveSkill?: string;
+  Gem?: PoBGem | PoBGem[];
+}
+
 // Path of Building build interface
 export interface PoBBuild {
   Build?: {
@@ -38,6 +61,7 @@ export interface PoBBuild {
     className?: string;
     ascendClassName?: string;
     bandit?: string;
+    mainSocketGroup?: string;
     PlayerStat?: Array<{stat: string; value: string}> | {stat: string; value: string};
   };
   Tree?: {
@@ -55,12 +79,8 @@ export interface PoBBuild {
     }>;
   };
   Skills?: {
-    SkillSet?: {
-      Skill?: Array<{
-        enabled?: string;
-        Gem?: Array<{nameSpec?: string; name?: string; level?: string; quality?: string}>;
-      }>;
-    };
+    activeSkillSet?: string;
+    SkillSet?: PoBSkillSet | PoBSkillSet[];
   };
   Items?: {
     Item?: Array<{

--- a/src/utils/xmlCollections.ts
+++ b/src/utils/xmlCollections.ts
@@ -1,0 +1,25 @@
+/**
+ * Helpers for PoB's XML shape.
+ *
+ * fast-xml-parser collapses a repeated element to a bare object when it occurs
+ * once, so every repeated node (`SkillSet`, `Skill`, `Gem`, ...) is either an
+ * array or a single object depending on the build. Normalising at the read site
+ * keeps that detail out of the callers.
+ */
+import type { PoBBuild, PoBSkillSet } from "../types.js";
+
+export function asArray<T>(value: T | T[] | undefined | null): T[] {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+/**
+ * The skill set the build actually has selected. Builds routinely carry several
+ * (league starter, endgame, bossing), so reading the first one is wrong whenever
+ * the user has switched.
+ */
+export function activeSkillSet(build: PoBBuild): PoBSkillSet | undefined {
+  const sets = asArray<PoBSkillSet>(build.Skills?.SkillSet);
+  const activeId = build.Skills?.activeSkillSet;
+  return sets.find(s => String(s.id) === String(activeId)) ?? sets[0];
+}

--- a/tests/unit/levelingHandlers.test.ts
+++ b/tests/unit/levelingHandlers.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from '@jest/globals';
+import { handlePlanLeveling, type LevelingContext } from '../../src/handlers/levelingHandlers.js';
+import type { PoBBuild } from '../../src/types.js';
+
+const textOf = (result: any) => result.content[0].text as string;
+
+const gem = (nameSpec: string, support = false) => ({
+  nameSpec,
+  skillId: support ? `Support${nameSpec.replace(/\s/g, '')}` : nameSpec.replace(/\s/g, ''),
+  gemId: `Metadata/Items/Gems/${support ? 'SupportGem' : 'SkillGem'}${nameSpec.replace(/\s/g, '')}`,
+});
+
+const build: PoBBuild = {
+  Build: { className: 'Templar', ascendClassName: 'Hierophant', mainSocketGroup: '2' },
+  Skills: {
+    activeSkillSet: '1',
+    SkillSet: {
+      id: '1',
+      Skill: [
+        { slot: 'Weapon 1', mainActiveSkill: '1', Gem: [gem('Purity of Elements')] },
+        {
+          slot: 'Body Armour',
+          mainActiveSkill: '1',
+          // A support sits ahead of the second active on purpose.
+          Gem: [gem('Crackling Lance'), gem('Spell Echo', true), gem('Shock Nova of Procession')],
+        },
+      ],
+    },
+  },
+};
+
+const contextFor = (b: PoBBuild): LevelingContext => ({
+  getLuaClient: () => null,
+  ensureLuaClient: async () => {},
+  readBuild: async () => b,
+});
+
+describe('handlePlanLeveling', () => {
+  it('reads class, ascendancy and main skill from the named build', async () => {
+    const result = await handlePlanLeveling(contextFor(build), { build_name: 'zappicus.xml' });
+
+    expect(textOf(result)).toContain('Templar (Hierophant)');
+    expect(textOf(result)).toContain('**Main Skill:** Crackling Lance');
+  });
+
+  it('honours mainActiveSkill when a group holds several actives', async () => {
+    const second = JSON.parse(JSON.stringify(build)) as PoBBuild;
+    (second.Skills!.SkillSet as any).Skill[1].mainActiveSkill = '2';
+
+    const result = await handlePlanLeveling(contextFor(second), { build_name: 'zappicus.xml' });
+
+    // Skipping the support means the second active is Shock Nova, not Spell Echo.
+    expect(textOf(result)).toContain('**Main Skill:** Shock Nova of Procession');
+  });
+
+  it('uses the active skill set rather than the first one', async () => {
+    const multi: PoBBuild = {
+      Build: { className: 'Witch', ascendClassName: 'Elementalist', mainSocketGroup: '1' },
+      Skills: {
+        activeSkillSet: '2',
+        SkillSet: [
+          { id: '1', Skill: [{ mainActiveSkill: '1', Gem: [gem('Freezing Pulse')] }] },
+          { id: '2', Skill: [{ mainActiveSkill: '1', Gem: [gem('Arc')] }] },
+        ],
+      },
+    };
+
+    const result = await handlePlanLeveling(contextFor(multi), { build_name: 'multi.xml' });
+
+    expect(textOf(result)).toContain('**Main Skill:** Arc');
+  });
+
+  it('lets explicit args override the build file', async () => {
+    const result = await handlePlanLeveling(contextFor(build), {
+      build_name: 'zappicus.xml',
+      main_skill: 'Armageddon Brand',
+    });
+
+    expect(textOf(result)).toContain('**Main Skill:** Armageddon Brand');
+    expect(textOf(result)).toContain('Templar (Hierophant)');
+  });
+
+  it('flags the output as generic when no build could be resolved', async () => {
+    const result = await handlePlanLeveling(
+      { getLuaClient: () => null, ensureLuaClient: async () => {} },
+      {}
+    );
+
+    expect(textOf(result)).toContain('No build was resolved');
+  });
+
+  it('fails instead of guessing when the named build cannot be read', async () => {
+    const context: LevelingContext = {
+      getLuaClient: () => null,
+      ensureLuaClient: async () => {},
+      readBuild: async () => { throw new Error('ENOENT: no such file'); },
+    };
+
+    await expect(handlePlanLeveling(context, { build_name: 'missing.xml' }))
+      .rejects.toThrow('ENOENT');
+  });
+});


### PR DESCRIPTION
Independent of #15 — different files, branched from `main`.

## `build_name` was accepted and ignored

`plan_leveling` advertises `build_name` as *"Build file to read class/skill from"*, but the handler never reads it. It only inspects whatever the Lua bridge happens to hold, so naming a build had no effect. Against a Templar Hierophant build:

```
# Leveling Guide: Scion (None)
**Main Skill:** your main skill

## Before Your Main Skill is Available
Use: **Cleave or Arc**
```

Passing `main_skill` alongside it changed only the skill line — the class stayed wrong, so the starter-skill recommendation stayed wrong too.

Now:

```
# Leveling Guide: Templar (Hierophant)
**Main Skill:** Crackling Lance

## Before Your Main Skill is Available
Use: **Holy Flame Totem or Arc**
```

## Silent fallback to Witch

When nothing resolved, the handler defaulted to `Witch` with no indication. A generic outline is a reasonable fallback; presenting it as the user's class is not — it turns a missing input into a confident wrong answer. It now labels itself, and a `build_name` that cannot be read raises instead of falling back to a guess.

## Reading the main skill out of XML

Deriving it needs the socket group PoB actually uses: `Build/@mainSocketGroup` for the group, `Skill/@mainActiveSkill` for the active within it, and supports filtered out — they share the `<Gem>` element with actives and frequently sit first in the link.

## `Skills/SkillSet` was typed as a single object

While typing that path: `PoBBuild` modelled `Skills.SkillSet` as one object. PoB emits one element per skill set, so any build with more than one — league starter plus endgame is the common case — parses as an array. The two existing readers in `advancedOptimizationHandlers.ts` guard `Array.isArray` on `Skill` but not on `SkillSet`, so for those builds `build.Skills.SkillSet.Skill` is `undefined` and they find **no skills at all**.

Both now resolve the set named by `Skills/@activeSkillSet` through a shared `activeSkillSet()` helper, so a user who switched skill sets is read correctly instead of being handed the first set's gems.

## Verification

`tsc` clean, full suite green (261 tests, 18 suites), 6 new tests covering: reading from the named build, `mainActiveSkill` selection past a support gem, active-skill-set selection, arg overrides, the unresolved-build notice, and the read failure.

Checked end-to-end against a real PoB checkout with all four argument combinations, including `build_name` pointing at a build whose main group holds two active skills.
