### PR TITLE
feat: use an installed PoB app as the engine, no checkout or Lua module setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ npm run build
 }
 ```
 
-#### Full Configuration (With Lua Bridge)
+#### With the Lua Bridge
+
+If PoB is installed (macOS), this is the whole configuration. `POB_PATH`, `POB_DIRECTORY`
+and `POB_CMD` are detected from the installed app.
+
 ```json
 {
   "mcpServers": {
@@ -120,24 +124,28 @@ npm run build
       "command": "node",
       "args": ["/absolute/path/to/pob-mcp-server/build/index.js"],
       "env": {
-        "POB_DIRECTORY": "/path/to/your/Path of Building/Builds",
-        "POB_LUA_ENABLED": "true",
-        "POB_PATH": "/path/to/PathOfBuilding/src",
-        "POB_CMD": "/usr/local/bin/luajit",
-        "POB_TIMEOUT_MS": "10000"
+        "POB_LUA_ENABLED": "true"
       }
     }
   }
 }
 ```
 
+Set `POB_PATH` explicitly only when driving a PathOfBuilding git checkout instead of an
+installed app, or when the app lives somewhere unusual:
+
+```json
+        "POB_PATH": "/path/to/PathOfBuilding/src",
+        "POB_CMD": "/opt/homebrew/bin/luajit"
+```
+
 ### Environment Variables
 
 | Variable | Default | Description |
 |---|---|---|
-| `POB_DIRECTORY` | OS-default Builds dir | Path to your PoB builds directory |
+| `POB_DIRECTORY` | detected Builds dir | Path to your PoB builds directory |
 | `POB_LUA_ENABLED` | `false` | Set `"true"` to enable Lua bridge |
-| `POB_PATH` | `~/Projects/PathOfBuilding/src` | Path to a stock PathOfBuilding checkout's `src/` directory (`POB_FORK_PATH` is accepted as a legacy alias) |
+| `POB_PATH` | installed PoB app, else `~/Projects/PathOfBuilding/src` | `src/` of a stock PathOfBuilding checkout. Usually unnecessary: an installed PoB is detected automatically (`POB_FORK_PATH` is a legacy alias) |
 | `POB_CMD` | `luajit` | LuaJIT binary path |
 | `POB_TIMEOUT_MS` | `10000` | Lua request timeout (ms) |
 | `POB_DEBUG` | `false` | Set `"true"` for verbose Lua bridge logging |
@@ -151,6 +159,24 @@ npm run build
 
 The Lua bridge uses PoB's actual calculation engine for accurate stats.
 
+#### If you already have Path of Building installed (macOS)
+
+Install LuaJIT and you are done:
+
+```bash
+brew install luajit
+```
+
+The server locates the engine inside the installed app, so there is no checkout to clone
+and no Lua modules to install. It uses the writable `src/` copy the app maintains under
+`~/Library/Application Support/PathOfBuildingMac`, which means the engine always matches
+the PoB you actually run, and the app's own C modules, which are the ones PoB ships no
+non-Windows build of in the repo.
+
+Skip to step 4 to verify.
+
+#### Working from a PathOfBuilding checkout instead
+
 #### 1. Install LuaJIT
 ```bash
 # macOS
@@ -162,7 +188,24 @@ sudo apt-get install luajit
 # Windows: download from https://luajit.org/ and add to PATH
 ```
 
-#### 2. Clone PathOfBuilding
+#### 2. Install PoB's Lua C modules (macOS and Linux)
+
+PoB commits its C modules to `runtime/` as Windows `.dll` builds only, so a checkout
+cannot supply them anywhere else. Without this the bridge appears to hang and then times
+out, because PoB reports `module 'lua-utf8' not found` and waits for a keypress that
+never comes.
+
+```bash
+luarocks --lua-version=5.1 --local install luautf8
+
+# Homebrew LuaJIT needs to be pointed at explicitly:
+luarocks --lua-version=5.1 --lua-dir=$(brew --prefix luajit) --local install luautf8
+```
+
+The bridge searches `~/.luarocks/lib/lua/5.1`, so `--local` is enough. Windows users can
+skip this: the bundled DLLs are used.
+
+#### 3. Clone PathOfBuilding
 ```bash
 git clone https://github.com/PathOfBuildingCommunity/PathOfBuilding.git
 ```
@@ -208,13 +251,13 @@ npm run test:smoke:crafting
 
 This verifies that the crafting advisor obtains current currency rates and base-mod data for a known item base through MCP.
 
-#### 3. Verify
+#### 4. Verify
 ```bash
 luajit -v
 ls /path/to/PathOfBuilding/src/HeadlessWrapper.lua
 ```
 
-#### 4. Update Claude Desktop config and restart Claude Desktop
+#### 5. Update Claude Desktop config and restart Claude Desktop
 
 ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import os from "os";
 import fs from "fs/promises";
 import { XMLParser } from "fast-xml-parser";
 // Import services
+import { defaultBuildsDirectory } from "./utils/pobLayout.js";
 import { BuildService } from "./services/buildService.js";
 import { TreeService } from "./services/treeService.js";
 import { WatchService } from "./services/watchService.js";
@@ -86,12 +87,7 @@ class PoBMCPServer {
     });
 
     // Default Path of Building directory (can be customized)
-    // Auto-detect based on platform
-    const defaultPoBPath = process.platform === 'darwin'
-      ? path.join(os.homedir(), "Path of Building", "Builds")  // macOS
-      : path.join(os.homedir(), "Documents", "Path of Building", "Builds");  // Windows/Linux
-
-    this.pobDirectory = process.env.POB_DIRECTORY || defaultPoBPath;
+    this.pobDirectory = process.env.POB_DIRECTORY || defaultBuildsDirectory();
 
     // Initialize services
     this.buildService = new BuildService(this.pobDirectory);

--- a/src/pobLuaBridge.ts
+++ b/src/pobLuaBridge.ts
@@ -2,6 +2,7 @@ import { spawn, ChildProcessWithoutNullStreams } from "child_process";
 import { EventEmitter } from "events";
 import path from "path";
 import os from "os";
+import { resolvePoBLayout } from "./utils/pobLayout.js";
 
 /** Lua bridge request envelope */
 type LuaRequest = { action: string; params?: Record<string, unknown> };
@@ -51,9 +52,9 @@ export class PoBLuaApiClient {
   constructor(options: PoBLuaApiOptions = {}) {
     // Prevent unhandled 'error' events (emitted on process exit) from crashing Node.js
     this.dataEmitter.on("error", () => {});
-    const forkSrc = options.cwd || process.env.POB_PATH || process.env.POB_FORK_PATH || path.join(os.homedir(), "Projects", "PathOfBuilding", "src");
+    const forkSrc = options.cwd || process.env.POB_PATH || process.env.POB_FORK_PATH;
     this.options = {
-      cwd: forkSrc,
+      cwd: forkSrc,  // may be undefined; resolved by layout detection in start()
       cmd: options.cmd || "luajit",
       args: options.args || ["HeadlessWrapper.lua"],
       env: options.env || {},
@@ -71,29 +72,18 @@ export class PoBLuaApiClient {
     this.ready = false;
     this.buffer = "";
 
-    // Set up Lua paths for runtime modules
-    const pobForkPath = this.options.cwd!;
+    const layout = resolvePoBLayout(this.options.cwd);
+    this.options.cwd = layout.src;
 
-    // Cross-platform path handling: remove 'src' from the end if present
-    const baseDir = pobForkPath.endsWith(path.sep + 'src') || pobForkPath.endsWith('/src')
-      ? pobForkPath.slice(0, -4)
-      : pobForkPath;
-    const runtimeDir = path.join(baseDir, 'runtime');
-    const runtimeLuaPath = path.join(runtimeDir, 'lua');
-    const luaRocksPath = path.join(os.homedir(), '.luarocks', 'lib', 'lua', '5.1');
-
-    // Platform-specific Lua paths
-    const isWindows = process.platform === 'win32';
-    const luaExt = isWindows ? 'dll' : 'so';
-
-    // Lua's package.path/cpath list separator is ';' on ALL platforms
+    // ';' separates entries on ALL platforms; trailing ';;' appends Lua's defaults
     const luaSep = ';';
+    const toSearchPath = (entries: string[]) => entries.join(luaSep) + luaSep + luaSep;
 
     const env = {
       ...process.env,
       POB_API_STDIO: "1",
-      LUA_PATH: `${runtimeLuaPath}${path.sep}?.lua${luaSep}${runtimeLuaPath}${path.sep}?${path.sep}init.lua${luaSep}${luaSep}`,
-      LUA_CPATH: `${runtimeDir}${path.sep}?.${luaExt}${luaSep}${luaRocksPath}${path.sep}?.${luaExt}${luaSep}${luaSep}`,
+      LUA_PATH: toSearchPath(layout.luaPath),
+      LUA_CPATH: toSearchPath(layout.luaCPath),
       ...this.options.env,
     } as NodeJS.ProcessEnv;
 

--- a/src/pobLuaBridge.ts
+++ b/src/pobLuaBridge.ts
@@ -8,6 +8,24 @@ type LuaRequest = { action: string; params?: Record<string, unknown> };
 /** Lua bridge response envelope — always an object with at minimum `ok: boolean` */
 type LuaResponse = { ok: boolean; error?: string; [key: string]: unknown };
 
+const ROCK_BY_LUA_MODULE: Record<string, string> = {
+  "lua-utf8": "luautf8",
+};
+
+/** PoB reports this on stdout and then blocks, so the bare symptom is a startup timeout. */
+function missingLuaModuleMessage(moduleName: string): string {
+  const rock = ROCK_BY_LUA_MODULE[moduleName];
+  return (
+    `Failed to start PoB Lua Bridge: PoB could not load the Lua module '${moduleName}'.\n\n` +
+    `PoB's C modules are committed to runtime/ as Windows .dll builds only, so a fresh\n` +
+    `PathOfBuilding checkout cannot supply them on macOS or Linux.\n\n` +
+    `Install it for LuaJIT (Lua 5.1):\n` +
+    `  luarocks --lua-version=5.1 --local install ${rock ?? moduleName}\n\n` +
+    `On Homebrew LuaJIT, add --lua-dir=$(brew --prefix luajit).\n` +
+    `This bridge already searches ~/.luarocks/lib/lua/5.1, so no extra config is needed.`
+  );
+}
+
 export interface PoBLuaApiOptions {
   cwd?: string;
   cmd?: string; // default: 'luajit'
@@ -163,6 +181,10 @@ export class PoBLuaApiClient {
 
         // Skip empty lines or lines that don't start with '{'
         if (!ready.trim() || !ready.trim().startsWith('{')) {
+          const missingModule = ready.match(/module '([\w.\-]+)' not found/);
+          if (missingModule) {
+            throw new Error(missingLuaModuleMessage(missingModule[1]));
+          }
           continue;
         }
 

--- a/src/utils/pobLayout.ts
+++ b/src/utils/pobLayout.ts
@@ -1,0 +1,112 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/** Where the Lua engine lives and how to reach its modules. */
+export interface PoBLayout {
+  kind: "checkout" | "macos-app";
+  /** Directory holding HeadlessWrapper.lua; the cwd for the Lua process. */
+  src: string;
+  luaPath: string[];
+  luaCPath: string[];
+}
+
+const exists = (p: string): boolean => {
+  try {
+    fs.accessSync(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+function appBundleCandidates(): string[] {
+  const home = os.homedir();
+  return [
+    "/Applications/Path of Building.app",
+    "/Applications/PathOfBuilding.app",
+    path.join(home, "Applications", "Path of Building.app"),
+    path.join(home, "Applications", "PathOfBuilding.app"),
+  ];
+}
+
+/** A bundle only counts if it carries the pure-Lua modules. */
+function findAppBundle(): string | null {
+  return appBundleCandidates().find((b) => exists(path.join(b, "Contents", "Resources", "lua"))) ?? null;
+}
+
+/** The launcher's updater keeps the Application Support copy current, so prefer it. */
+function macAppSrcCandidates(bundle: string): string[] {
+  return [
+    path.join(os.homedir(), "Library", "Application Support", "PathOfBuildingMac", "src"),
+    path.join(bundle, "Contents", "Resources", "src"),
+  ];
+}
+
+const stripSrc = (p: string): string =>
+  p.endsWith(`${path.sep}src`) || p.endsWith("/src") ? p.slice(0, -4) : p;
+
+function checkoutLayout(src: string): PoBLayout {
+  const base = stripSrc(src);
+  const runtime = path.join(base, "runtime");
+  const runtimeLua = path.join(runtime, "lua");
+  const luaRocks = path.join(os.homedir(), ".luarocks", "lib", "lua", "5.1");
+  const ext = process.platform === "win32" ? "dll" : "so";
+
+  return {
+    kind: "checkout",
+    src,
+    luaPath: [path.join(runtimeLua, "?.lua"), path.join(runtimeLua, "?", "init.lua")],
+    // runtime/ first so a checkout's own modules win over luarocks
+    luaCPath: [path.join(runtime, `?.${ext}`), path.join(luaRocks, `?.${ext}`)],
+  };
+}
+
+function macAppLayout(bundle: string, src: string): PoBLayout {
+  const lua = path.join(bundle, "Contents", "Resources", "lua");
+  const macos = path.join(bundle, "Contents", "MacOS");
+
+  return {
+    kind: "macos-app",
+    src,
+    // sha1 is a directory module, hence the ?/init.lua entry
+    luaPath: [path.join(lua, "?.lua"), path.join(lua, "?", "init.lua")],
+    // the bundle ships .dylib rather than .so
+    luaCPath: [path.join(macos, "?.dylib")],
+  };
+}
+
+/**
+ * An explicit src wins, treated as a checkout unless it has no sibling runtime/ and an
+ * app is installed. Otherwise prefer an installed app: no setup, and always the same
+ * PoB the user runs.
+ */
+export function resolvePoBLayout(explicitSrc?: string): PoBLayout {
+  const bundle = process.platform === "darwin" ? findAppBundle() : null;
+
+  if (explicitSrc) {
+    return !exists(path.join(stripSrc(explicitSrc), "runtime")) && bundle
+      ? macAppLayout(bundle, explicitSrc)
+      : checkoutLayout(explicitSrc);
+  }
+
+  if (bundle) {
+    const src = macAppSrcCandidates(bundle).find((s) => exists(path.join(s, "HeadlessWrapper.lua")));
+    if (src) return macAppLayout(bundle, src);
+  }
+
+  return checkoutLayout(path.join(os.homedir(), "Projects", "PathOfBuilding", "src"));
+}
+
+/** Where the installed PoB actually writes builds. */
+export function defaultBuildsDirectory(): string {
+  const home = os.homedir();
+  if (process.platform !== "darwin") {
+    return path.join(home, "Documents", "Path of Building", "Builds");
+  }
+  // current port uses Application Support; the older Qt port used ~/Path of Building
+  const appSupport = path.join(home, "Library", "Application Support", "Path of Building", "Builds");
+  const legacy = path.join(home, "Path of Building", "Builds");
+  if (exists(appSupport)) return appSupport;
+  return exists(legacy) ? legacy : appSupport;
+}

--- a/tests/unit/pobLayout.test.ts
+++ b/tests/unit/pobLayout.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, jest, beforeEach, afterAll } from '@jest/globals';
+import path from 'path';
+import os from 'os';
+
+// The resolver decides on which paths exist, so drive it with a fake fs
+const present = new Set<string>();
+jest.mock('fs', () => ({
+  __esModule: true,
+  default: {
+    accessSync: (p: string) => {
+      if (!present.has(p)) throw new Error(`ENOENT: ${p}`);
+    },
+  },
+}));
+
+import { resolvePoBLayout, defaultBuildsDirectory } from '../../src/utils/pobLayout.js';
+
+const realPlatform = process.platform;
+function setPlatform(value: string): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+beforeEach(() => {
+  present.clear();
+  setPlatform(realPlatform);
+});
+
+afterAll(() => {
+  setPlatform(realPlatform);
+});
+
+const BUNDLE = '/Applications/Path of Building.app';
+const BUNDLE_LUA = path.join(BUNDLE, 'Contents', 'Resources', 'lua');
+const APP_SRC = path.join(os.homedir(), 'Library', 'Application Support', 'PathOfBuildingMac', 'src');
+
+describe('resolvePoBLayout', () => {
+  it('should treat an explicit src with a sibling runtime as a checkout', () => {
+    present.add('/repo/runtime');
+
+    const layout = resolvePoBLayout('/repo/src');
+
+    expect(layout.kind).toBe('checkout');
+    expect(layout.src).toBe('/repo/src');
+    expect(layout.luaPath[0]).toBe(path.join('/repo', 'runtime', 'lua', '?.lua'));
+  });
+
+  it('should search the checkout runtime before luarocks', () => {
+    present.add('/repo/runtime');
+
+    const layout = resolvePoBLayout('/repo/src');
+
+    expect(layout.luaCPath[0]).toContain(path.join('/repo', 'runtime'));
+    expect(layout.luaCPath[1]).toContain('.luarocks');
+  });
+
+  it('should use an installed app when no path is configured', () => {
+    setPlatform('darwin');
+    present.add(BUNDLE_LUA);
+    present.add(path.join(APP_SRC, 'HeadlessWrapper.lua'));
+
+    const layout = resolvePoBLayout();
+
+    expect(layout.kind).toBe('macos-app');
+    expect(layout.src).toBe(APP_SRC);
+    // the bundle ships .dylib, not .so
+    expect(layout.luaCPath[0]).toBe(path.join(BUNDLE, 'Contents', 'MacOS', '?.dylib'));
+    // sha1 is a directory module; dropping this breaks loading only *after* the
+    // ready banner, surfacing as "build not initialized" on the first request
+    expect(layout.luaPath).toContain(path.join(BUNDLE_LUA, '?', 'init.lua'));
+  });
+
+  it('should fall back to the bundled src when the app has never been launched', () => {
+    setPlatform('darwin');
+    present.add(BUNDLE_LUA);
+    present.add(path.join(BUNDLE, 'Contents', 'Resources', 'src', 'HeadlessWrapper.lua'));
+
+    const layout = resolvePoBLayout();
+
+    expect(layout.src).toBe(path.join(BUNDLE, 'Contents', 'Resources', 'src'));
+  });
+
+  it('should adopt an installed app for an explicit src that has no runtime beside it', () => {
+    setPlatform('darwin');
+    present.add(BUNDLE_LUA);
+
+    const layout = resolvePoBLayout(APP_SRC);
+
+    expect(layout.kind).toBe('macos-app');
+    expect(layout.src).toBe(APP_SRC);
+  });
+
+  it('should stay a checkout when nothing is installed', () => {
+    setPlatform('linux');
+
+    const layout = resolvePoBLayout('/repo/src');
+
+    expect(layout.kind).toBe('checkout');
+  });
+});
+
+describe('defaultBuildsDirectory', () => {
+  // Only observable when both exist, as on a machine that used the old port first
+  it('should prefer the current port when both locations exist', () => {
+    setPlatform('darwin');
+    const appSupport = path.join(os.homedir(), 'Library', 'Application Support', 'Path of Building', 'Builds');
+    present.add(appSupport);
+    present.add(path.join(os.homedir(), 'Path of Building', 'Builds'));
+
+    expect(defaultBuildsDirectory()).toBe(appSupport);
+  });
+
+  it('should use the older port location when only that exists', () => {
+    setPlatform('darwin');
+    const legacy = path.join(os.homedir(), 'Path of Building', 'Builds');
+    present.add(legacy);
+
+    expect(defaultBuildsDirectory()).toBe(legacy);
+  });
+});

--- a/tests/unit/pobLuaBridge.test.ts
+++ b/tests/unit/pobLuaBridge.test.ts
@@ -68,6 +68,34 @@ describe('PoBLuaApiClient', () => {
       await expect(client.start()).rejects.toThrow(/Timed out|Failed to find valid ready banner/);
     });
 
+    it('should explain a missing PoB Lua C module rather than reporting a timeout', async () => {
+      client = new PoBLuaApiClient({ timeoutMs: 1000 });
+
+      // PoB prints the load failure to stdout and never emits a ready banner
+      mockSpawn.mockImplementationOnce(() => {
+        const proc = new MockPoBProcess();
+        const emit = proc.stdout.emit.bind(proc.stdout);
+        (proc.stdout as any).emit = (event: string, data?: unknown) => {
+          if (event === 'data' && typeof data === 'string' && data.includes('"ready":true')) {
+            return emit(
+              'data',
+              'Loading main script...\n' +
+                "Error loading main script: Modules/Common.lua:29: module 'lua-utf8' not found:\n"
+            );
+          }
+          return emit(event, data as never);
+        };
+        return proc;
+      });
+
+      const error = await client.start().catch((e: Error) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toContain("module 'lua-utf8'");
+      expect((error as Error).message).toContain('luarocks');
+      expect((error as Error).message).toContain('luautf8');
+    });
+
     it('should handle multiple non-JSON lines before ready banner', async () => {
       mockSpawn.mockImplementationOnce(() => {
         const proc = new MockPoBProcess();


### PR DESCRIPTION
**Use an installed Path of Building as the calculation engine, instead of requiring a separate checkout.**

Setting up the Lua bridge on macOS needs LuaJIT, luarocks plus `luautf8`, an 852 MB PathOfBuilding clone, and four env vars. An installed PoB already holds all of it: `src/`, the pure-Lua modules, and C modules built for the platform.

This detects an installed app and uses it. Full config becomes:

```json
"env": { "POB_LUA_ENABLED": "true" }
```

## Layout resolution

`start()` hardcoded `<base>/runtime/lua` for `LUA_PATH` and `<base>/runtime/?.so` for `LUA_CPATH`, which only describes a checkout. `src/utils/pobLayout.ts` resolves either shape:

| | checkout | installed app |
|---|---|---|
| `src` | `<base>/src` | `~/Library/Application Support/PathOfBuildingMac/src` |
| Lua modules | `<base>/runtime/lua` | `Contents/Resources/lua` |
| C modules | `<base>/runtime/?.so` + luarocks | `Contents/MacOS/?.dylib` |

Before, the two search paths were built inline from a shape the code assumed:

```ts
const runtimeDir = path.join(baseDir, 'runtime');
const runtimeLuaPath = path.join(runtimeDir, 'lua');
const luaRocksPath = path.join(os.homedir(), '.luarocks', 'lib', 'lua', '5.1');
const luaExt = process.platform === 'win32' ? 'dll' : 'so';

LUA_PATH: `${runtimeLuaPath}${path.sep}?.lua${luaSep}${runtimeLuaPath}${path.sep}?${path.sep}init.lua${luaSep}${luaSep}`,
LUA_CPATH: `${runtimeDir}${path.sep}?.${luaExt}${luaSep}${luaRocksPath}${path.sep}?.${luaExt}${luaSep}${luaSep}`,
```

After, the shape is detected and the bridge only joins entries:

```ts
const layout = resolvePoBLayout(this.options.cwd);
this.options.cwd = layout.src;

// ';' separates entries on ALL platforms; trailing ';;' appends Lua's defaults
const toSearchPath = (entries: string[]) => entries.join(luaSep) + luaSep + luaSep;

LUA_PATH: toSearchPath(layout.luaPath),
LUA_CPATH: toSearchPath(layout.luaCPath),
```

- Prefers the app's writable `src/` copy, which the launcher's updater keeps current, so the engine matches the PoB being run.
- An explicit `POB_PATH` still wins, and is still read as a checkout when a sibling `runtime/` exists. Existing setups are unchanged.
- Detection is on what exists on disk.

## Other changes

`src/index.ts`: the builds-dir default moves to where the current macOS port actually writes. The old macOS default was the Qt port's location, which is why `POB_DIRECTORY` had to be set by hand.

Before:

```ts
const defaultPoBPath = process.platform === 'darwin'
  ? path.join(os.homedir(), "Path of Building", "Builds")  // macOS
  : path.join(os.homedir(), "Documents", "Path of Building", "Builds");

this.pobDirectory = process.env.POB_DIRECTORY || defaultPoBPath;
```

After:

```ts
this.pobDirectory = process.env.POB_DIRECTORY || defaultBuildsDirectory();
```

On macOS that prefers `~/Library/Application Support/Path of Building/Builds`, uses `~/Path of Building/Builds` when only the older Qt location exists, and falls back to Application Support when neither is present. Windows and Linux keep `~/Documents/Path of Building/Builds`.

`src/pobLuaBridge.ts`: a missing C module now reports the module and the fix. PoB prints the failure to stdout, never emits a ready banner, then blocks on a dismiss prompt, so the symptom was `Timed out waiting for response` after the full `POB_TIMEOUT_MS`.

## Verified

- Zero config, macOS 15.5 arm64: builds listed, engine started, build loaded, stats correct. Same numbers as a v2.66.2 checkout.
- Checkout path re-checked with `POB_PATH` set to that checkout.
- 264 tests, 18 suites. `tsc --noEmit` clean.
- Layout tests mutation-checked: disabling detection fails 3 tests, dropping the app layout's `?/init.lua` entry fails 1, removing the builds-dir preference fails 1.

## Limits

Detection is macOS-only; Windows and Linux keep current behaviour. A new platform is a branch and a candidate list. LuaJIT itself is untouched, so it is still installed separately (#3).

Product +120 net, docs +43, tests +147.
