### PR TITLE
fix: error on a missing build instead of silently reporting another one

### DIFF
--- a/src/handlers/advancedOptimizationHandlers.ts
+++ b/src/handlers/advancedOptimizationHandlers.ts
@@ -11,7 +11,7 @@ import {
   formatSkillOptimization,
   type SkillGroup,
 } from "../skillLinkOptimizer.js";
-import { resolveBuildFile } from "../utils/pathSanitizer.js";
+import { readNamedBuild } from "../utils/namedBuild.js";
 
 export interface AdvancedOptimizationContext {
   buildService: BuildService;
@@ -54,13 +54,8 @@ export async function handleAnalyzeItems(
           }
         } catch { /* no build loaded yet */ }
         if (needsLoad) {
-          try {
-            const buildPath = resolveBuildFile(buildName, context.pobDirectory);
-            const xml = await fs.readFile(buildPath, 'utf-8');
-            await luaClient.loadBuildXml(xml, buildName);
-          } catch {
-            // Build file not found — use whichever build is currently loaded in Lua bridge
-          }
+          const xml = await readNamedBuild(buildName, context.pobDirectory);
+          await luaClient.loadBuildXml(xml, buildName);
         }
       }
 
@@ -180,14 +175,8 @@ export async function handleOptimizeSkillLinks(
     if (luaClient) {
       // Load build if buildName provided
       if (buildName) {
-        const fs2 = await import('fs/promises');
-        try {
-          const buildPath = resolveBuildFile(buildName, context.pobDirectory);
-          const xml = await fs2.readFile(buildPath, 'utf-8');
-          await luaClient.loadBuildXml(xml, buildName);
-        } catch {
-          // Build file not found — use whichever build is currently loaded in Lua bridge
-        }
+        const xml = await readNamedBuild(buildName, context.pobDirectory);
+        await luaClient.loadBuildXml(xml, buildName);
       }
 
       try {

--- a/src/handlers/advancedOptimizationHandlers.ts
+++ b/src/handlers/advancedOptimizationHandlers.ts
@@ -11,7 +11,7 @@ import {
   formatSkillOptimization,
   type SkillGroup,
 } from "../skillLinkOptimizer.js";
-import { sanitizeBuildName } from "../utils/pathSanitizer.js";
+import { resolveBuildFile } from "../utils/pathSanitizer.js";
 
 export interface AdvancedOptimizationContext {
   buildService: BuildService;
@@ -55,7 +55,7 @@ export async function handleAnalyzeItems(
         } catch { /* no build loaded yet */ }
         if (needsLoad) {
           try {
-            const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+            const buildPath = resolveBuildFile(buildName, context.pobDirectory);
             const xml = await fs.readFile(buildPath, 'utf-8');
             await luaClient.loadBuildXml(xml, buildName);
           } catch {
@@ -182,7 +182,7 @@ export async function handleOptimizeSkillLinks(
       if (buildName) {
         const fs2 = await import('fs/promises');
         try {
-          const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+          const buildPath = resolveBuildFile(buildName, context.pobDirectory);
           const xml = await fs2.readFile(buildPath, 'utf-8');
           await luaClient.loadBuildXml(xml, buildName);
         } catch {

--- a/src/handlers/buildHandlers.ts
+++ b/src/handlers/buildHandlers.ts
@@ -5,7 +5,7 @@ import type { TreeAnalysisResult } from "../types.js";
 import type { HandlerContext } from "../utils/contextBuilder.js";
 import fs from "fs/promises";
 import { wrapHandler } from "../utils/errorHandling.js";
-import { sanitizeBuildName } from "../utils/pathSanitizer.js";
+import { resolveBuildFile } from "../utils/pathSanitizer.js";
 export type { HandlerContext } from "../utils/contextBuilder.js";
 
 export async function handleListBuilds(context: HandlerContext) {
@@ -64,7 +64,7 @@ export async function handleAnalyzeBuild(context: HandlerContext, buildName: str
       } catch { /* no build loaded yet — safe to load */ }
 
       if (shouldLoad) {
-        const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+        const buildPath = resolveBuildFile(buildName, context.pobDirectory);
         const buildXml = await fs.readFile(buildPath, 'utf-8');
         await luaClient.loadBuildXml(buildXml);
       }
@@ -236,7 +236,7 @@ export async function handleCompareBuilds(context: HandlerContext, build1Name: s
   // saved state matches what the user sees in PoB and avoids reporting wrong stats
   // (e.g. resistances from a different gear set than the one the user expects).
   const loadEndgame = async (luaClient: any, buildName: string) => {
-    const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+    const buildPath = resolveBuildFile(buildName, context.pobDirectory);
     const buildXml = await fs.readFile(buildPath, 'utf-8');
     const displayName = buildName.replace(/\.xml$/i, '').split(/[/\\]/).pop() ?? buildName;
     await luaClient.loadBuildXml(buildXml, displayName);
@@ -444,7 +444,7 @@ export async function handleGetBuildNotes(context: HandlerContext, buildName: st
 
 export async function handleSetBuildNotes(context: HandlerContext, buildName: string, notes: string) {
   return wrapHandler('set build notes', async () => {
-    const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+    const buildPath = resolveBuildFile(buildName, context.pobDirectory);
     let xml = await fs.readFile(buildPath, 'utf-8');
 
     // XML-escape the notes content so special characters don't corrupt the build file

--- a/src/handlers/luaHandlers.ts
+++ b/src/handlers/luaHandlers.ts
@@ -3,7 +3,7 @@ import { handleGetBuildIssues } from "./buildGoalsHandlers.js";
 import fs from "fs/promises";
 import path from "path";
 import { wrapHandler } from "../utils/errorHandling.js";
-import { sanitizeBuildName } from "../utils/pathSanitizer.js";
+import { buildFileName, resolveBuildFile } from "../utils/pathSanitizer.js";
 
 export interface LuaHandlerContext {
   pobDirectory: string;
@@ -79,8 +79,8 @@ export async function handleLuaSaveBuild(context: LuaHandlerContext, buildName: 
       throw new Error('build_name is required');
     }
 
-    const fileName = buildName.endsWith('.xml') ? buildName : `${buildName}.xml`;
-    const filePath = sanitizeBuildName(fileName, context.pobDirectory);
+    const fileName = buildFileName(buildName);
+    const filePath = resolveBuildFile(fileName, context.pobDirectory);
     const result = await luaClient.saveBuild(filePath);
 
     return {
@@ -111,7 +111,7 @@ export async function handleLuaLoadBuild(
     // If build_name is provided, read the file
     let xml = buildXml;
     if (buildName) {
-      const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+      const buildPath = resolveBuildFile(buildName, context.pobDirectory);
       xml = await fs.readFile(buildPath, 'utf-8');
       // Use the build filename as the name if not specified
       if (!name) {
@@ -558,7 +558,7 @@ export async function handleLuaReloadBuild(context: LuaHandlerContext, buildName
     }
 
     const fileName = targetName.endsWith('.xml') ? targetName : `${targetName}.xml`;
-    const buildPath = sanitizeBuildName(fileName, context.pobDirectory);
+    const buildPath = resolveBuildFile(fileName, context.pobDirectory);
     const xml = await fs.readFile(buildPath, 'utf-8');
     const name = fileName.replace(/\.xml$/i, '');
     await luaClient.loadBuildXml(xml, name);

--- a/src/handlers/luaHandlers.ts
+++ b/src/handlers/luaHandlers.ts
@@ -557,7 +557,7 @@ export async function handleLuaReloadBuild(context: LuaHandlerContext, buildName
       targetName = String(info.name);
     }
 
-    const fileName = targetName.endsWith('.xml') ? targetName : `${targetName}.xml`;
+    const fileName = buildFileName(targetName);
     const buildPath = resolveBuildFile(fileName, context.pobDirectory);
     const xml = await fs.readFile(buildPath, 'utf-8');
     const name = fileName.replace(/\.xml$/i, '');

--- a/src/handlers/optimizationHandlers.ts
+++ b/src/handlers/optimizationHandlers.ts
@@ -5,7 +5,7 @@ import type { OptimizationConstraints } from "../types/optimization.js";
 import fs from "fs/promises";
 import { analyzeDefenses, formatDefensiveAnalysis } from "../defensiveAnalyzer.js";
 import { wrapHandler } from "../utils/errorHandling.js";
-import { sanitizeBuildName } from "../utils/pathSanitizer.js";
+import { resolveBuildFile } from "../utils/pathSanitizer.js";
 
 export interface OptimizationHandlerContext {
   buildService: BuildService;
@@ -46,7 +46,7 @@ export async function handleAnalyzeDefenses(
     } catch { /* no build loaded yet */ }
 
     if (needsLoad) {
-      const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+      const buildPath = resolveBuildFile(buildName, context.pobDirectory);
       const buildXml = await fs.readFile(buildPath, 'utf-8');
       await luaClient.loadBuildXml(buildXml, buildName);
     }
@@ -112,7 +112,7 @@ export async function handleSuggestOptimalNodes(
     // Load build from disk if buildName refers to an existing file, otherwise
     // assume a build is already loaded in the Lua bridge (in-memory workflow)
     if (buildName) {
-      const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+      const buildPath = resolveBuildFile(buildName, context.pobDirectory);
       try {
         const buildXml = await fs.readFile(buildPath, 'utf-8');
         await luaClient.loadBuildXml(buildXml, buildName);
@@ -277,7 +277,7 @@ export async function handleOptimizeTree(
 
     // Load build from disk if it exists, otherwise use the currently loaded Lua build
     if (buildName) {
-      const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+      const buildPath = resolveBuildFile(buildName, context.pobDirectory);
       try {
         const buildXml = await fs.readFile(buildPath, 'utf-8');
         await luaClient.loadBuildXml(buildXml, buildName);

--- a/src/handlers/optimizationHandlers.ts
+++ b/src/handlers/optimizationHandlers.ts
@@ -6,6 +6,7 @@ import fs from "fs/promises";
 import { analyzeDefenses, formatDefensiveAnalysis } from "../defensiveAnalyzer.js";
 import { wrapHandler } from "../utils/errorHandling.js";
 import { resolveBuildFile } from "../utils/pathSanitizer.js";
+import { readNamedBuild } from "../utils/namedBuild.js";
 
 export interface OptimizationHandlerContext {
   buildService: BuildService;
@@ -112,13 +113,8 @@ export async function handleSuggestOptimalNodes(
     // Load build from disk if buildName refers to an existing file, otherwise
     // assume a build is already loaded in the Lua bridge (in-memory workflow)
     if (buildName) {
-      const buildPath = resolveBuildFile(buildName, context.pobDirectory);
-      try {
-        const buildXml = await fs.readFile(buildPath, 'utf-8');
-        await luaClient.loadBuildXml(buildXml, buildName);
-      } catch {
-        // Build file not found — use whichever build is currently loaded in Lua bridge
-      }
+      const buildXml = await readNamedBuild(buildName, context.pobDirectory);
+      await luaClient.loadBuildXml(buildXml, buildName);
     }
 
     const points = pointsAvailable || 10;
@@ -277,13 +273,8 @@ export async function handleOptimizeTree(
 
     // Load build from disk if it exists, otherwise use the currently loaded Lua build
     if (buildName) {
-      const buildPath = resolveBuildFile(buildName, context.pobDirectory);
-      try {
-        const buildXml = await fs.readFile(buildPath, 'utf-8');
-        await luaClient.loadBuildXml(buildXml, buildName);
-      } catch {
-        // Build file not found — use whichever build is currently loaded in Lua bridge
-      }
+      const buildXml = await readNamedBuild(buildName, context.pobDirectory);
+      await luaClient.loadBuildXml(buildXml, buildName);
     }
 
     const points = maxPoints || 10;

--- a/src/handlers/validationHandlers.ts
+++ b/src/handlers/validationHandlers.ts
@@ -4,7 +4,7 @@ import type { PoBLuaApiClient } from "../pobLuaBridge.js";
 import fs from "fs/promises";
 import path from "path";
 import { wrapHandler } from "../utils/errorHandling.js";
-import { sanitizeBuildName } from "../utils/pathSanitizer.js";
+import { resolveBuildFile } from "../utils/pathSanitizer.js";
 
 export interface ValidationHandlerContext {
   buildService: BuildService;
@@ -52,7 +52,7 @@ export async function handleValidateBuild(
 
           if (shouldLoad) {
             try {
-              const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
+              const buildPath = resolveBuildFile(buildName, context.pobDirectory);
               const buildXml = await fs.readFile(buildPath, 'utf-8');
               await luaClient.loadBuildXml(buildXml, buildName);
             } catch {

--- a/src/handlers/validationHandlers.ts
+++ b/src/handlers/validationHandlers.ts
@@ -1,10 +1,8 @@
 import type { BuildService } from "../services/buildService.js";
 import type { ValidationService } from "../services/validationService.js";
 import type { PoBLuaApiClient } from "../pobLuaBridge.js";
-import fs from "fs/promises";
-import path from "path";
 import { wrapHandler } from "../utils/errorHandling.js";
-import { resolveBuildFile } from "../utils/pathSanitizer.js";
+import { readNamedBuild } from "../utils/namedBuild.js";
 
 export interface ValidationHandlerContext {
   buildService: BuildService;
@@ -28,39 +26,37 @@ export async function handleValidateBuild(
   let luaStats;
   const buildName = args?.build_name;
 
+  // A named build must exist. Checked before touching the Lua bridge so the error
+  // is the same whether or not a bridge is running, and so a miss can never fall
+  // through to whatever build happens to be in memory.
+  const namedBuildXml = buildName ? await readNamedBuild(buildName, context.pobDirectory) : undefined;
+
   // Try to get Lua bridge stats (works for both file-loaded and in-memory builds)
   let luaFlaskImmunities: { bleed: boolean; freeze: boolean; poison: boolean; curse: boolean } | null = null;
   if (getLuaClient) {
     const luaClient = getLuaClient();
     if (luaClient) {
       try {
-        // If a build name is provided and file exists, load it only if:
-        // - no build is currently loaded, OR
-        // - the same build is already loaded (safe reload)
-        // Never replace a *different* in-memory build to avoid data loss.
-        if (buildName && context.pobDirectory) {
-          let shouldLoad = true;
+        let otherBuildInMemory = false;
+        if (namedBuildXml !== undefined && buildName) {
           try {
             const info = await luaClient.getBuildInfo();
             const loadedName: string = info?.name ?? '';
             const requested = buildName.replace(/\.xml$/i, '');
             const loaded    = loadedName.replace(/\.xml$/i, '');
-            if (loaded && loaded !== requested) {
-              shouldLoad = false; // different build in memory — skip
-            }
+            otherBuildInMemory = Boolean(loaded) && loaded !== requested;
           } catch { /* no build loaded — safe to load */ }
 
-          if (shouldLoad) {
-            try {
-              const buildPath = resolveBuildFile(buildName, context.pobDirectory);
-              const buildXml = await fs.readFile(buildPath, 'utf-8');
-              await luaClient.loadBuildXml(buildXml, buildName);
-            } catch {
-              // File doesn't exist — use already-loaded in-memory build
-            }
+          if (!otherBuildInMemory) {
+            await luaClient.loadBuildXml(namedBuildXml, buildName);
           }
         }
-        luaStats = await luaClient.getStats();
+        // A different in-memory build is never replaced, to protect unsaved work,
+        // but its stats are not the requested build's, so skip them and let the
+        // XML below speak for the build that was actually asked about.
+        if (!otherBuildInMemory) {
+          luaStats = await luaClient.getStats();
+        }
 
         // Get flask immunities from Lua bridge (more reliable than XML slot parsing)
         try {

--- a/src/services/buildExportService.ts
+++ b/src/services/buildExportService.ts
@@ -2,7 +2,7 @@ import { XMLBuilder } from "fast-xml-parser";
 import fs from "fs/promises";
 import path from "path";
 import type { PoBBuild, SnapshotMetadata } from "../types.js";
-import { sanitizeBuildName } from "../utils/pathSanitizer.js";
+import { resolveBuildFile, sanitizeBuildName } from "../utils/pathSanitizer.js";
 
 export interface ExportOptions {
   outputName: string;
@@ -91,7 +91,7 @@ export class BuildExportService {
    * Update only the passive tree in an existing build file
    */
   async saveTree(buildService: any, options: SaveTreeOptions): Promise<{ message: string; backupPath?: string }> {
-    const buildPath = sanitizeBuildName(options.buildName, this.pobDirectory);
+    const buildPath = resolveBuildFile(options.buildName, this.pobDirectory);
 
     // Create backup if requested
     let backupPath: string | undefined;
@@ -166,7 +166,7 @@ export class BuildExportService {
     const snapshotPath = path.join(buildSnapshotDir, snapshotFileName);
 
     // Read and copy build
-    const buildPath = sanitizeBuildName(options.buildName, this.pobDirectory);
+    const buildPath = resolveBuildFile(options.buildName, this.pobDirectory);
     const buildContent = await fs.readFile(buildPath, 'utf-8');
     await fs.writeFile(snapshotPath, buildContent, 'utf-8');
 
@@ -301,13 +301,13 @@ export class BuildExportService {
       backupId = timestamp.toISOString().replace(/[:.]/g, '-').split('.')[0];
 
       const backupPath = path.join(buildSnapshotDir, `${backupId}_before-restore.xml`);
-      const buildPath = sanitizeBuildName(options.buildName, this.pobDirectory);
+      const buildPath = resolveBuildFile(options.buildName, this.pobDirectory);
       const currentContent = await fs.readFile(buildPath, 'utf-8');
       await fs.writeFile(backupPath, currentContent, 'utf-8');
     }
 
     // Restore from snapshot
-    const buildPath = sanitizeBuildName(options.buildName, this.pobDirectory);
+    const buildPath = resolveBuildFile(options.buildName, this.pobDirectory);
     const snapshotContent = await fs.readFile(snapshot.filePath, 'utf-8');
     await fs.writeFile(buildPath, snapshotContent, 'utf-8');
 
@@ -382,7 +382,7 @@ export class BuildExportService {
    * Create a timestamped backup of a build
    */
   private async createBackup(buildName: string): Promise<string> {
-    const buildPath = sanitizeBuildName(buildName, this.pobDirectory);
+    const buildPath = resolveBuildFile(buildName, this.pobDirectory);
     const buildSnapshotDir = sanitizeBuildName(buildName, this.snapshotDirectory);
     await fs.mkdir(buildSnapshotDir, { recursive: true });
 

--- a/src/services/buildService.ts
+++ b/src/services/buildService.ts
@@ -2,7 +2,7 @@ import { XMLParser } from "fast-xml-parser";
 import fs from "fs/promises";
 import path from "path";
 import type { PoBBuild, CachedBuild, ParsedConfiguration, ConfigInput, ConfigSet, Flask, FlaskAnalysis, Jewel, JewelAnalysis } from "../types.js";
-import { sanitizeBuildName } from "../utils/pathSanitizer.js";
+import { resolveBuildFile } from "../utils/pathSanitizer.js";
 
 const CACHE_TTL_MS = 60_000;  // 60 seconds
 const CACHE_MAX_SIZE = 20;
@@ -62,7 +62,7 @@ export class BuildService {
     }
 
     // Cache miss or expired — read from file
-    const buildPath = sanitizeBuildName(buildName, this.pobDirectory);
+    const buildPath = resolveBuildFile(buildName, this.pobDirectory);
     const content = await fs.readFile(buildPath, "utf-8");
     const parsed = this.parser.parse(content);
     const buildData = parsed.PathOfBuilding;

--- a/src/utils/namedBuild.ts
+++ b/src/utils/namedBuild.ts
@@ -1,0 +1,24 @@
+import fs from "fs/promises";
+import { resolveBuildFile } from "./pathSanitizer.js";
+
+/**
+ * Read a named build, failing loudly when it does not exist.
+ *
+ * Swallowing the miss and continuing with whatever the Lua bridge holds reports
+ * another build's numbers under the requested name, with no error.
+ */
+export async function readNamedBuild(buildName: string, buildsDir?: string): Promise<string> {
+  if (!buildsDir) {
+    throw new Error(`Cannot resolve build "${buildName}": no builds directory configured.`);
+  }
+
+  const buildPath = resolveBuildFile(buildName, buildsDir);
+  try {
+    return await fs.readFile(buildPath, "utf-8");
+  } catch {
+    throw new Error(
+      `Build "${buildName}" not found in ${buildsDir}. ` +
+      `Use list_builds for available names, or omit build_name to use the build already loaded in the Lua bridge.`
+    );
+  }
+}

--- a/src/utils/pathSanitizer.ts
+++ b/src/utils/pathSanitizer.ts
@@ -1,6 +1,22 @@
 import path from "path";
 
 /**
+ * PoB build files are always .xml, so a build name means the same thing with or
+ * without the suffix. list_builds reports names with it; callers routinely omit it.
+ */
+export function buildFileName(name: string): string {
+  return /\.xml$/i.test(name) ? name : `${name}.xml`;
+}
+
+/**
+ * Resolve a build name to its file path inside the builds directory.
+ * Normalizes the suffix first, then applies the full traversal checks below.
+ */
+export function resolveBuildFile(name: string, buildsDir: string): string {
+  return sanitizeBuildName(buildFileName(name), buildsDir);
+}
+
+/**
  * Sanitize a build name to prevent path traversal attacks.
  * Returns the resolved absolute path within baseDir.
  * Throws on any path that would escape baseDir.

--- a/tests/unit/buildService.test.ts
+++ b/tests/unit/buildService.test.ts
@@ -97,6 +97,13 @@ describe('BuildService', () => {
       expect(build.Build?.ascendClassName).toBe('Deadeye');
     });
 
+    it('should read a build named without the .xml suffix', async () => {
+      await fs.writeFile(path.join(tempDir, 'suffixless.xml'), sampleBuild);
+
+      const build = await buildService.readBuild('suffixless');
+      expect(build.Build?.className).toBe('Ranger');
+    });
+
     it('should cache build after first read', async () => {
       await fs.writeFile(path.join(tempDir, 'cached.xml'), sampleBuild);
 

--- a/tests/unit/luaReloadBuild.test.ts
+++ b/tests/unit/luaReloadBuild.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+
+const readFile = jest.fn(async (..._args: unknown[]) => '<?xml version="1.0"?><PathOfBuilding/>');
+jest.mock('fs/promises', () => ({ __esModule: true, default: { readFile } }));
+
+import { handleLuaReloadBuild } from '../../src/handlers/luaHandlers.js';
+
+describe('handleLuaReloadBuild', () => {
+  const loadBuildXml = jest.fn(async (..._args: unknown[]) => ({}));
+
+  const context = {
+    pobDirectory: '/builds',
+    getLuaClient: () => ({ loadBuildXml, getBuildInfo: async () => ({ name: 'whatever' }) }),
+    ensureLuaClient: async () => {},
+  } as any;
+
+  beforeEach(() => {
+    readFile.mockClear();
+    loadBuildXml.mockClear();
+  });
+
+  it('appends the suffix when the name lacks one', async () => {
+    await handleLuaReloadBuild(context, 'Luminary');
+
+    expect(readFile).toHaveBeenCalledTimes(1);
+    expect(String(readFile.mock.calls[0][0])).toBe('/builds/Luminary.xml');
+  });
+
+  // The suffix check has to be case-insensitive, matching buildFileName and the
+  // display-name strip on the next line. A case-sensitive endsWith produces
+  // "Luminary.XML.xml", which then fails to read.
+  it('treats an uppercase suffix as already present', async () => {
+    await handleLuaReloadBuild(context, 'Luminary.XML');
+
+    expect(String(readFile.mock.calls[0][0])).toBe('/builds/Luminary.XML');
+  });
+
+  it('strips the suffix for the name handed to the bridge', async () => {
+    await handleLuaReloadBuild(context, 'Luminary.XML');
+
+    expect(loadBuildXml).toHaveBeenCalledWith(expect.any(String), 'Luminary');
+  });
+});

--- a/tests/unit/namedBuild.test.ts
+++ b/tests/unit/namedBuild.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { readNamedBuild } from '../../src/utils/namedBuild.js';
+import { handleValidateBuild } from '../../src/handlers/validationHandlers.js';
+
+describe('readNamedBuild', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pob-named-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('should return the build contents', async () => {
+    await fs.writeFile(path.join(dir, 'Mine.xml'), '<PathOfBuilding/>');
+
+    await expect(readNamedBuild('Mine.xml', dir)).resolves.toBe('<PathOfBuilding/>');
+  });
+
+  it('should name the build, the directory, and the in-memory route it did not take', async () => {
+    await expect(readNamedBuild('Ghost', dir)).rejects.toThrow(/Ghost.*not found in.*omit build_name/s);
+  });
+});
+
+describe('handleValidateBuild with a name that does not exist', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pob-validate-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  // Previously the failed read was swallowed and the bridge's build was reported
+  // under the requested name, so a wrong name produced a confident wrong report
+  it('should fail rather than report on whatever the bridge holds', async () => {
+    const luaClient = {
+      getBuildInfo: async () => ({ name: 'SomethingElse', level: 93 }),
+      getStats: async () => ({ Life: 3283 }),
+      getItems: async () => [],
+      loadBuildXml: async () => undefined,
+    };
+
+    const result = handleValidateBuild(
+      {
+        buildService: { readBuild: async () => { throw new Error('ENOENT'); } } as any,
+        validationService: { validateBuild: () => ({}), formatValidation: () => '' } as any,
+        pobDirectory: dir,
+        getLuaClient: () => luaClient as any,
+        ensureLuaClient: async () => {},
+      },
+      { build_name: 'NoSuchBuild' }
+    );
+
+    await expect(result).rejects.toThrow(/NoSuchBuild.*not found/s);
+  });
+});

--- a/tests/unit/pathSanitizer.test.ts
+++ b/tests/unit/pathSanitizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { sanitizeBuildName } from '../../src/utils/pathSanitizer';
+import { sanitizeBuildName, buildFileName, resolveBuildFile } from '../../src/utils/pathSanitizer';
 import path from 'path';
 
 describe('sanitizeBuildName', () => {
@@ -38,5 +38,35 @@ describe('sanitizeBuildName', () => {
   it('should accept deeply nested valid paths', () => {
     const result = sanitizeBuildName('a/b/c/build.xml', baseDir);
     expect(result).toBe(path.resolve(baseDir, 'a', 'b', 'c', 'build.xml'));
+  });
+});
+
+describe('buildFileName', () => {
+  it('should append .xml only when absent, whatever the case', () => {
+    expect(buildFileName('Mine')).toBe('Mine.xml');
+    expect(buildFileName('Mine.xml')).toBe('Mine.xml');
+    expect(buildFileName('Mine.XML')).toBe('Mine.XML');
+  });
+
+  it('should not mistake a dot in the name for a suffix', () => {
+    expect(buildFileName('v2.1 boss farmer')).toBe('v2.1 boss farmer.xml');
+  });
+});
+
+describe('resolveBuildFile', () => {
+  const baseDir = '/home/user/.config/PathOfBuilding/Builds';
+
+  it('should append the suffix to the final segment of a subdirectory build', () => {
+    expect(resolveBuildFile('league/starter', baseDir)).toBe(
+      path.resolve(baseDir, 'league', 'starter.xml')
+    );
+  });
+
+  // Appending the suffix must not open a hole in the traversal checks
+  it('should still reject traversal, absolute paths and null bytes', () => {
+    expect(() => resolveBuildFile('../../etc/passwd', baseDir)).toThrow();
+    expect(() => resolveBuildFile('/etc/passwd', baseDir)).toThrow();
+    expect(() => resolveBuildFile('foo\0bar', baseDir)).toThrow();
+    expect(() => resolveBuildFile('..\\..\\windows\\system32', baseDir)).toThrow();
   });
 });


### PR DESCRIPTION
## The bug

Ask for a build that does not exist, get a confident report about a different one.

With `Mine` loaded in the Lua bridge (level 93, 3,283 life), asking about a name that exists nowhere:

```
validate_build("NoSuchBuild")        -> "Life could be higher (3283). Aim for 5000+."
suggest_optimal_nodes("NoSuchBuild") -> Cannot read properties of undefined (reading 'toLowerCase')
```

3,283 is Mine's life. Neither tool raises an error.

Cause: five handlers read the named build and swallow the failure, each with the same comment.

Before, from `handleSuggestOptimalNodes`, the shortest of the five sites:

```ts
if (buildName) {
  const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
  try {
    const buildXml = await fs.readFile(buildPath, 'utf-8');
    await luaClient.loadBuildXml(buildXml, buildName);
  } catch {
    // Build file not found — use whichever build is currently loaded in Lua bridge
  }
}
```

After, the read either succeeds or the tool fails:

```ts
if (buildName) {
  const buildXml = await readNamedBuild(buildName, context.pobDirectory);
  await luaClient.loadBuildXml(buildXml, buildName);
}
```

```
validate_build("NoSuchBuild")        -> Build "NoSuchBuild" not found in <builds dir>.
                                        Use list_builds for available names, or omit
                                        build_name to use the build already loaded.
suggest_optimal_nodes("NoSuchBuild") -> same
```

## Changes

- `readNamedBuild()` in `src/utils/namedBuild.ts`: reads a named build or throws with the name and directory. Replaces the swallow in `validationHandlers`, `optimizationHandlers` (2 sites), `advancedOptimizationHandlers` (2 sites).
- `validate_build` second defect: when a *different* build was in memory it skipped loading, to protect unsaved work, then used that build's stats anyway. It still refuses to clobber, and now validates the requested build from XML rather than reporting the other build's numbers.

  Before, the flag that guarded the load did not guard the stats:

  ```ts
  if (loaded && loaded !== requested) {
    shouldLoad = false; // different build in memory — skip
  }
  ...
  luaStats = await luaClient.getStats();
  ```

  After:

  ```ts
  otherBuildInMemory = Boolean(loaded) && loaded !== requested;
  ...
  if (!otherBuildInMemory) {
    luaStats = await luaClient.getStats();
  }
  ```

- Existence check hoisted above the Lua block, so the error is identical with or without a running bridge.
- `resolveBuildFile()` accepts a name with or without `.xml`. Secondary: `lua_save_build` already normalised it while reads did not, and `list_builds` prints `Mine.xml` while load replies print `Mine`, so without this the new hard failure fires on names the server itself printed.

  Before, every read site sanitised a name it assumed already carried the suffix:

  ```ts
  const buildPath = sanitizeBuildName(buildName, context.pobDirectory);
  ```

  After, one helper normalises first, then applies the same traversal checks:

  ```ts
  export function resolveBuildFile(name: string, buildsDir: string): string {
    return sanitizeBuildName(buildFileName(name), buildsDir);
  }
  ```

Unaffected: omitting `build_name` to validate the in-memory build. That route is intended, and the error now names it.

## Tests

Every test was mutation-checked; each line below is a mutant and the tests that caught it.

| mutant | caught by |
|---|---|
| handler swallows the miss again | `should fail rather than report on whatever the bridge holds` |
| `readNamedBuild` returns `""` instead of throwing | `should name the build, the directory, and the in-memory route it did not take` |
| `resolveBuildFile` skips normalisation | `readBuild('suffixless')`, subdirectory suffix case |
| `buildFileName` always appends | case-insensitivity case, `readNamedBuild` happy path, 4 pre-existing |

Two tests fire on no mutant and are kept deliberately: the traversal/null-byte/absolute-path assertions on `resolveBuildFile`, since appending before sanitising must not open a hole, and the dot-in-name case, which an `includes('.')` implementation would break.

263 tests, 18 suites. `tsc --noEmit` clean. Before/after output above captured through MCP stdio against both builds.

Product +16 net (86 added, 70 removed). Tests +101.
