### PR TITLE
fix: get_stats returned no damage stats to seven of its callers

### DIFF
--- a/lua/pob_ops.lua
+++ b/lua/pob_ops.lua
@@ -37,7 +37,12 @@ function M.export_stats(fields)
   if not output then
     return nil, err
   end
+  -- Callers that pass no field list get this set, so it has to answer "how is
+  -- this build doing" on both axes. Damage was missing entirely, which made
+  -- every such caller report a build as if it dealt none.
   local wanted = fields or {
+    "TotalDPS", "CombinedDPS", "FullDPS", "AverageDamage", "Speed",
+    "CritChance", "CritMultiplier",
     "Life", "EnergyShield", "Armour", "Evasion",
     "FireResist", "ColdResist", "LightningResist", "ChaosResist",
     "BlockChance", "SpellBlockChance",

--- a/tests/smoke/bridge.mjs
+++ b/tests/smoke/bridge.mjs
@@ -33,6 +33,22 @@ try {
   if (!info?.className || !Array.isArray(tree?.nodes) || typeof stats.Life !== 'number' || !Array.isArray(items) || !Array.isArray(skillSetup?.groups)) {
     throw new Error('unexpected adapter response shape');
   }
+  // Seven handlers call getStats() with no field list, so the default set decides
+  // what they can report. It carried no damage stat at all, which made every one
+  // of them describe a build as if it dealt none.
+  await client.createSocketGroup({ label: 'dps', slot: 'Weapon 1' });
+  const dpsGroup = (await client.getSkills()).groups.length;
+  await client.addGem({ groupIndex: dpsGroup, gemName: 'Arc', level: 20, quality: 0 });
+  await client.setMainSelection({ mainSocketGroup: dpsGroup });
+  const defaults = await client.getStats();
+  for (const field of ['TotalDPS', 'CombinedDPS', 'AverageDamage']) {
+    if (typeof defaults[field] !== 'number') {
+      throw new Error(`getStats() with no fields must include ${field}: ${JSON.stringify(defaults)}`);
+    }
+  }
+  if (!(defaults.TotalDPS > 0)) throw new Error(`expected a positive TotalDPS, got ${defaults.TotalDPS}`);
+  if (typeof defaults.Life !== 'number') throw new Error('the defensive defaults must survive too');
+
   const changed = await client.setTree({ ...tree, ascendClassId: 0, nodes: [] });
   // Upstream keeps the class start allocated even when given an empty node list.
   if (changed.ascendClassId !== 0 || changed.nodes.length >= tree.nodes.length) throw new Error('tree mutation was not applied');


### PR DESCRIPTION
`get_stats` returns no damage. Not for one tool: the default field set is what **seven** handlers get, and it contained no damage stat at all, so each of them described a build as if it dealt none.

## Where it comes from

`lua/pob_ops.lua`, the list used whenever a caller passes no fields:

```lua
  local wanted = fields or {
    "Life", "EnergyShield", "Armour", "Evasion",
    "FireResist", "ColdResist", "LightningResist", "ChaosResist",
    ...
    "EnduranceChargesMax", "FrenzyChargesMax", "PowerChargesMax",
  }
```

Every entry is defensive. There is no `TotalDPS`, no `CombinedDPS`, nothing.

The callers relying on it:

| caller | tool |
|---|---|
| `optimizationHandlers.ts:55` | `analyze_defenses` |
| `optimizationHandlers.ts:221` | `suggest_optimal_nodes` |
| `optimizationHandlers.ts:293` | `optimize_tree` |
| `validationHandlers.ts:63` | `validate_build` |
| `buildHandlers.ts:71` | `analyze_build` |
| `buildHandlers.ts:262` | `compare_builds` |
| `advancedOptimizationHandlers.ts:77` | `analyze_items` |

`lua_get_stats` is affected too. Its handler passes explicit fields for `category='offense'` and `'defense'`, but `'all'` (the default) passes `undefined` and falls through to the list above. Measured on `main`, against a build doing 125k:

```
lua_get_stats (default / 'all') Offense section:
  EffectiveMovementSpeedMod: 1.34
  PhysicalDamageReduction: 1

mentions TotalDPS? false | CombinedDPS? false
```

An "Offense" heading over two stats, neither of them offensive.

## After

```lua
  local wanted = fields or {
    "TotalDPS", "CombinedDPS", "FullDPS", "AverageDamage", "Speed",
    "CritChance", "CritMultiplier",
    "Life", "EnergyShield", "Armour", "Evasion",
```

Fixed at the default rather than at each call site, so all seven callers and `lua_get_stats` are covered by one change. Against a real level 59 build:

```
before:  TotalDPS: undefined | CombinedDPS: undefined | AverageDamage: undefined
after:   TotalDPS: 139,789   | CombinedDPS: 155,235   | AverageDamage: 15,618
         Life: 928 | TotalEHP: 31,325 | FireResist: 55   (defensive defaults unchanged)
```

Minion damage already came through separately via the `Minion` sub-table, and is untouched.

## Relationship to #15

#15 hits the same wall from the other side and works around it at the `compare_builds` call site, with the comment *"get_stats defaults to defence-only fields, so the offensive rows below have to be requested by name"*. That workaround stays correct and more precise than the default; this PR just means the next caller does not have to rediscover it. The two do not overlap in any file and merge cleanly in either order.

## Tests

`tests/smoke/bridge.mjs` asserts against the real engine that a build with a damaging skill returns `TotalDPS`, `CombinedDPS` and `AverageDamage` as numbers from a no-field `getStats()`, with `TotalDPS > 0`, and that `Life` still comes back so the defensive half is not traded away.

Mutation-checked by reverting the field list: all three read `undefined` while the defensive fields stay populated.

Existing tests, typecheck and build are clean.

Product +7 net (7 added, 0 removed). Tests +16.
